### PR TITLE
Updating evaluation library, adding tests

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -85,15 +85,6 @@ jobs:
           
           ./build/Poker.PokerEval/pokenum -r As 2s 3s 4s Kh - Th 9h 8h 7h 6h / Qd Jd Td 9d
            
-          ./build/Poker.PokerEval/pokenum -5d As Xx / Qh Td 9s - 8h 7h 4h 3h / Ks
-          ./build/Poker.PokerEval/pokenum -5d As Ac / Qh Td 9s - 8h 7h Xx 3h / Ks
-          ./build/Poker.PokerEval/pokenum -5d As Ac / Qh Td 9s - 8h 7h 4h 3h / Ks
-          ./build/Poker.PokerEval/pokenum -5d8 As Ac / Qh Td 9s - 8h 7h 4h 3h / Ks
-          ./build/Poker.PokerEval/pokenum -5dnsq As Ac / Qh Td 9s - 8h 7h 4h 3h / Ks
-          
-          ./build/Poker.PokerEval/pokenum -l 5h 4h 3h 2h / 5s - 9s 8h 6d 4c / Kd
-          ./build/Poker.PokerEval/pokenum -l 5h 4h 3h 2h / 5s - 9s 6d 4c Xx / Kd
-          
           ./build/Poker.PokerEval/pokenum -l27 As 2s 3s 4s 5d - Ac 3c 4c 5c 6d
           ./build/Poker.PokerEval/pokenum -l27 5h 4h 3h 2h / 5s - 9s 8h 6d 4c / Kd
           

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -20,6 +20,15 @@ jobs:
             build/libPokerEquity.so
             build/libPokerEval.a
             build/PokerEquityTest
+            build/Poker.PokerEval/joktest1
+            build/Poker.PokerEval/enumtest1
+            build/Poker.PokerEval/enumtest2
+            build/Poker.PokerEval/enumtest3
+            build/Poker.PokerEval/enumtest5
+            build/Poker.PokerEval/enumtest7
+            build/Poker.PokerEval/poker_wrapper
+            build/Poker.PokerEval/razz
+            build/Poker.PokerEval/pokenum
           retention-days: 1
 
   test:
@@ -33,5 +42,64 @@ jobs:
           path: build
       - name: Test
         run: |
-          chmod +x build/PokerEquityTest
-          build/PokerEquityTest
+          chmod +x ./build/PokerEquityTest
+          chmod +x ./build/joktest1
+          chmod +x ./build/enumtest1
+          chmod +x ./build/enumtest2
+          chmod +x ./build/enumtest3
+          chmod +x ./build/enumtest5
+          chmod +x ./build/enumtest7
+          chmod +x ./build/poker_wrapper
+          chmod +x ./build/razz
+          chmod +x ./build/pokenum
+          ./build/PokerEquityTest
+          [ $(./build/enumtest1 6 3 | md5sum | awk '{print $1}') = 425daf38998180d6f261ac6801d589dd ]
+          [ $(./build/enumtest2 | md5sum | awk '{print $1}') = 1e144704f542b3046c174bcfc3c1f2a2 ]
+          [ $(./build/enumtest3 | md5sum | awk '{print $1}') = 8eca9e9a0aa0e4ad71acafbc8a93da4a ]
+          [ $(./build/enumtest5 | md5sum | awk '{print $1}') = 74c0f1347023859feab2275dc8c33ef1 ]
+          [ $(./build/enumtest7 | md5sum | awk '{print $1}') = 02d548445d51f7ddf2b99ff878b49277 ]
+          ./build/razz
+          ./build/poker_wrapper
+          ./build/pokenum -h Ac 7c - 5s 4s - Ks Kd -- 7h 2c 3h
+          ./build/pokenum -h Ac 7c - 5s 4s - Ks Kd -- 7h 2c 3h / Ah
+          
+          ./build/pokenum -h8 Ac 7c  5s 4s  Ks Kd -- 7h 2c 3h
+          
+          ./build/pokenum -o As Kh Qs Jh - 8h 8d 7h 6d -- 8s Ts Jc
+          
+          ./build/pokenum -o8 As Kh Qs Jh - 8h 8d 7h 6d -- 8s Ts Jc
+          
+          ./build/pokenum -7s As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h
+          ./build/pokenum -7s As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h / 5c 6c 7c
+          
+          ./build/pokenum -7s8 As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h
+          ./build/pokenum -7s8 As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h / 5c 6c 7c
+          
+          ./build/pokenum -7snsq As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h
+          ./build/pokenum -7snsq As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h / 5c 6c 7c
+          
+          ./build/pokenum -r As 2s 3s 4s Kh - Th 9h 8h 7h 6h / Qd Jd Td 9d
+           
+          ./build/pokenum -5d As Xx / Qh Td 9s - 8h 7h 4h 3h / Ks
+          ./build/pokenum -5d As Ac / Qh Td 9s - 8h 7h Xx 3h / Ks
+          ./build/pokenum -5d As Ac / Qh Td 9s - 8h 7h 4h 3h / Ks
+          ./build/pokenum -5d8 As Ac / Qh Td 9s - 8h 7h 4h 3h / Ks
+          ./build/pokenum -5dnsq As Ac / Qh Td 9s - 8h 7h 4h 3h / Ks
+          
+          ./build/pokenum -l 5h 4h 3h 2h / 5s - 9s 8h 6d 4c / Kd
+          ./build/pokenum -l 5h 4h 3h 2h / 5s - 9s 6d 4c Xx / Kd
+          
+          ./build/pokenum -l27 As 2s 3s 4s 5d - Ac 3c 4c 5c 6d
+          ./build/pokenum -l27 5h 4h 3h 2h / 5s - 9s 8h 6d 4c / Kd
+          
+          ./build/pokenum -mc 10000 -h Ac 7c - 5s 4s - Ks Kd
+          ./build/pokenum -mc 10000 -h Ac 7c - 5s 4s - Ks Kd -- 7h 2c 3h
+          ./build/pokenum -mc 10000 -h8 Ac 7c - 5s 4s - Ks Kd
+          ./build/pokenum -mc 10000 -o As Kh Qs Jh - 8h 8d 7h 6d
+          ./build/pokenum -mc 10000 -o8 As Kh Qs Jh - 8h 8d 7h 6d
+          ./build/pokenum -mc 10000 -7s As Ah Ts -  7c 6c 5c
+          ./build/pokenum -mc 10000 -7s8 As Ah Ts - 7c 6c 5c
+          ./build/pokenum -mc 10000 -7snsq As Ah Ts -  7c 6c 5c
+          ./build/pokenum -mc 10000 -r As 2s 3s 4s Kh - Th 9h 8h 7h 6h / Qd Jd Td 9d
+          ./build/pokenum -mc 10000 -l27 5h 4h 3h 2h / 5s - 9s 8h 6d 4c / Kd
+          ./build/pokenum -mc 10000 -l27 5h 4h 3h / 5s Qd - 9s 8h 6d / Kd Ks

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -62,6 +62,7 @@ jobs:
           [ $(./build/Poker.PokerEval/enumtest3 | md5sum | awk '{print $1}') = 8eca9e9a0aa0e4ad71acafbc8a93da4a ]
           [ $(./build/Poker.PokerEval/enumtest5 | md5sum | awk '{print $1}') = 74c0f1347023859feab2275dc8c33ef1 ]
           [ $(./build/Poker.PokerEval/enumtest7 | md5sum | awk '{print $1}') = 02d548445d51f7ddf2b99ff878b49277 ]
+          
           ./build/Poker.PokerEval/razz
           ./build/Poker.PokerEval/poker_wrapper
           ./build/Poker.PokerEval/pokenum -h Ac 7c - 5s 4s - Ks Kd -- 7h 2c 3h

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -12,8 +12,6 @@ jobs:
           cd build
           cmake ..
           make
-          ls -larth
-          ls -larth Poker.PokerEval/
       - name: Store Build
         uses: actions/upload-artifact@v2
         with:
@@ -44,8 +42,6 @@ jobs:
           path: build
       - name: Test
         run: |
-          ls -larth
-          ls -larth build/
           chmod +x ./build/PokerEquityTest
           chmod +x ./build/Poker.PokerEval/joktest1
           chmod +x ./build/Poker.PokerEval/enumtest1

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -47,63 +47,63 @@ jobs:
           ls -larth
           ls -larth build/
           chmod +x ./build/PokerEquityTest
-          chmod +x ./build/joktest1
-          chmod +x ./build/enumtest1
-          chmod +x ./build/enumtest2
-          chmod +x ./build/enumtest3
-          chmod +x ./build/enumtest5
-          chmod +x ./build/enumtest7
-          chmod +x ./build/poker_wrapper
-          chmod +x ./build/razz
-          chmod +x ./build/pokenum
+          chmod +x ./build/Poker.PokerEval/joktest1
+          chmod +x ./build/Poker.PokerEval/enumtest1
+          chmod +x ./build/Poker.PokerEval/enumtest2
+          chmod +x ./build/Poker.PokerEval/enumtest3
+          chmod +x ./build/Poker.PokerEval/enumtest5
+          chmod +x ./build/Poker.PokerEval/enumtest7
+          chmod +x ./build/Poker.PokerEval/poker_wrapper
+          chmod +x ./build/Poker.PokerEval/razz
+          chmod +x ./build/Poker.PokerEval/pokenum
           ./build/PokerEquityTest
-          [ $(./build/enumtest1 6 3 | md5sum | awk '{print $1}') = 425daf38998180d6f261ac6801d589dd ]
-          [ $(./build/enumtest2 | md5sum | awk '{print $1}') = 1e144704f542b3046c174bcfc3c1f2a2 ]
-          [ $(./build/enumtest3 | md5sum | awk '{print $1}') = 8eca9e9a0aa0e4ad71acafbc8a93da4a ]
-          [ $(./build/enumtest5 | md5sum | awk '{print $1}') = 74c0f1347023859feab2275dc8c33ef1 ]
-          [ $(./build/enumtest7 | md5sum | awk '{print $1}') = 02d548445d51f7ddf2b99ff878b49277 ]
-          ./build/razz
-          ./build/poker_wrapper
-          ./build/pokenum -h Ac 7c - 5s 4s - Ks Kd -- 7h 2c 3h
-          ./build/pokenum -h Ac 7c - 5s 4s - Ks Kd -- 7h 2c 3h / Ah
+          [ $(./build/Poker.PokerEval/enumtest1 6 3 | md5sum | awk '{print $1}') = 425daf38998180d6f261ac6801d589dd ]
+          [ $(./build/Poker.PokerEval/enumtest2 | md5sum | awk '{print $1}') = 1e144704f542b3046c174bcfc3c1f2a2 ]
+          [ $(./build/Poker.PokerEval/enumtest3 | md5sum | awk '{print $1}') = 8eca9e9a0aa0e4ad71acafbc8a93da4a ]
+          [ $(./build/Poker.PokerEval/enumtest5 | md5sum | awk '{print $1}') = 74c0f1347023859feab2275dc8c33ef1 ]
+          [ $(./build/Poker.PokerEval/enumtest7 | md5sum | awk '{print $1}') = 02d548445d51f7ddf2b99ff878b49277 ]
+          ./build/Poker.PokerEval/razz
+          ./build/Poker.PokerEval/poker_wrapper
+          ./build/Poker.PokerEval/pokenum -h Ac 7c - 5s 4s - Ks Kd -- 7h 2c 3h
+          ./build/Poker.PokerEval/pokenum -h Ac 7c - 5s 4s - Ks Kd -- 7h 2c 3h / Ah
           
-          ./build/pokenum -h8 Ac 7c  5s 4s  Ks Kd -- 7h 2c 3h
+          ./build/Poker.PokerEval/pokenum -h8 Ac 7c  5s 4s  Ks Kd -- 7h 2c 3h
           
-          ./build/pokenum -o As Kh Qs Jh - 8h 8d 7h 6d -- 8s Ts Jc
+          ./build/Poker.PokerEval/pokenum -o As Kh Qs Jh - 8h 8d 7h 6d -- 8s Ts Jc
           
-          ./build/pokenum -o8 As Kh Qs Jh - 8h 8d 7h 6d -- 8s Ts Jc
+          ./build/Poker.PokerEval/pokenum -o8 As Kh Qs Jh - 8h 8d 7h 6d -- 8s Ts Jc
           
-          ./build/pokenum -7s As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h
-          ./build/pokenum -7s As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h / 5c 6c 7c
+          ./build/Poker.PokerEval/pokenum -7s As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h
+          ./build/Poker.PokerEval/pokenum -7s As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h / 5c 6c 7c
           
-          ./build/pokenum -7s8 As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h
-          ./build/pokenum -7s8 As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h / 5c 6c 7c
+          ./build/Poker.PokerEval/pokenum -7s8 As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h
+          ./build/Poker.PokerEval/pokenum -7s8 As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h / 5c 6c 7c
           
-          ./build/pokenum -7snsq As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h
-          ./build/pokenum -7snsq As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h / 5c 6c 7c
+          ./build/Poker.PokerEval/pokenum -7snsq As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h
+          ./build/Poker.PokerEval/pokenum -7snsq As Ah Ts Th 8h 8d - Kc Qc Jc Td 3c 2d - Ac 2h 3h 3d 7s 7h / 5c 6c 7c
           
-          ./build/pokenum -r As 2s 3s 4s Kh - Th 9h 8h 7h 6h / Qd Jd Td 9d
+          ./build/Poker.PokerEval/pokenum -r As 2s 3s 4s Kh - Th 9h 8h 7h 6h / Qd Jd Td 9d
            
-          ./build/pokenum -5d As Xx / Qh Td 9s - 8h 7h 4h 3h / Ks
-          ./build/pokenum -5d As Ac / Qh Td 9s - 8h 7h Xx 3h / Ks
-          ./build/pokenum -5d As Ac / Qh Td 9s - 8h 7h 4h 3h / Ks
-          ./build/pokenum -5d8 As Ac / Qh Td 9s - 8h 7h 4h 3h / Ks
-          ./build/pokenum -5dnsq As Ac / Qh Td 9s - 8h 7h 4h 3h / Ks
+          ./build/Poker.PokerEval/pokenum -5d As Xx / Qh Td 9s - 8h 7h 4h 3h / Ks
+          ./build/Poker.PokerEval/pokenum -5d As Ac / Qh Td 9s - 8h 7h Xx 3h / Ks
+          ./build/Poker.PokerEval/pokenum -5d As Ac / Qh Td 9s - 8h 7h 4h 3h / Ks
+          ./build/Poker.PokerEval/pokenum -5d8 As Ac / Qh Td 9s - 8h 7h 4h 3h / Ks
+          ./build/Poker.PokerEval/pokenum -5dnsq As Ac / Qh Td 9s - 8h 7h 4h 3h / Ks
           
-          ./build/pokenum -l 5h 4h 3h 2h / 5s - 9s 8h 6d 4c / Kd
-          ./build/pokenum -l 5h 4h 3h 2h / 5s - 9s 6d 4c Xx / Kd
+          ./build/Poker.PokerEval/pokenum -l 5h 4h 3h 2h / 5s - 9s 8h 6d 4c / Kd
+          ./build/Poker.PokerEval/pokenum -l 5h 4h 3h 2h / 5s - 9s 6d 4c Xx / Kd
           
-          ./build/pokenum -l27 As 2s 3s 4s 5d - Ac 3c 4c 5c 6d
-          ./build/pokenum -l27 5h 4h 3h 2h / 5s - 9s 8h 6d 4c / Kd
+          ./build/Poker.PokerEval/pokenum -l27 As 2s 3s 4s 5d - Ac 3c 4c 5c 6d
+          ./build/Poker.PokerEval/pokenum -l27 5h 4h 3h 2h / 5s - 9s 8h 6d 4c / Kd
           
-          ./build/pokenum -mc 10000 -h Ac 7c - 5s 4s - Ks Kd
-          ./build/pokenum -mc 10000 -h Ac 7c - 5s 4s - Ks Kd -- 7h 2c 3h
-          ./build/pokenum -mc 10000 -h8 Ac 7c - 5s 4s - Ks Kd
-          ./build/pokenum -mc 10000 -o As Kh Qs Jh - 8h 8d 7h 6d
-          ./build/pokenum -mc 10000 -o8 As Kh Qs Jh - 8h 8d 7h 6d
-          ./build/pokenum -mc 10000 -7s As Ah Ts -  7c 6c 5c
-          ./build/pokenum -mc 10000 -7s8 As Ah Ts - 7c 6c 5c
-          ./build/pokenum -mc 10000 -7snsq As Ah Ts -  7c 6c 5c
-          ./build/pokenum -mc 10000 -r As 2s 3s 4s Kh - Th 9h 8h 7h 6h / Qd Jd Td 9d
-          ./build/pokenum -mc 10000 -l27 5h 4h 3h 2h / 5s - 9s 8h 6d 4c / Kd
-          ./build/pokenum -mc 10000 -l27 5h 4h 3h / 5s Qd - 9s 8h 6d / Kd Ks
+          ./build/Poker.PokerEval/pokenum -mc 10000 -h Ac 7c - 5s 4s - Ks Kd
+          ./build/Poker.PokerEval/pokenum -mc 10000 -h Ac 7c - 5s 4s - Ks Kd -- 7h 2c 3h
+          ./build/Poker.PokerEval/pokenum -mc 10000 -h8 Ac 7c - 5s 4s - Ks Kd
+          ./build/Poker.PokerEval/pokenum -mc 10000 -o As Kh Qs Jh - 8h 8d 7h 6d
+          ./build/Poker.PokerEval/pokenum -mc 10000 -o8 As Kh Qs Jh - 8h 8d 7h 6d
+          ./build/Poker.PokerEval/pokenum -mc 10000 -7s As Ah Ts -  7c 6c 5c
+          ./build/Poker.PokerEval/pokenum -mc 10000 -7s8 As Ah Ts - 7c 6c 5c
+          ./build/Poker.PokerEval/pokenum -mc 10000 -7snsq As Ah Ts -  7c 6c 5c
+          ./build/Poker.PokerEval/pokenum -mc 10000 -r As 2s 3s 4s Kh - Th 9h 8h 7h 6h / Qd Jd Td 9d
+          ./build/Poker.PokerEval/pokenum -mc 10000 -l27 5h 4h 3h 2h / 5s - 9s 8h 6d 4c / Kd
+          ./build/Poker.PokerEval/pokenum -mc 10000 -l27 5h 4h 3h / 5s Qd - 9s 8h 6d / Kd Ks

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -12,6 +12,8 @@ jobs:
           cd build
           cmake ..
           make
+          ls -larth
+          ls -larth Poker.PokerEval/
       - name: Store Build
         uses: actions/upload-artifact@v2
         with:
@@ -42,6 +44,8 @@ jobs:
           path: build
       - name: Test
         run: |
+          ls -larth
+          ls -larth build/
           chmod +x ./build/PokerEquityTest
           chmod +x ./build/joktest1
           chmod +x ./build/enumtest1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,42 +4,7 @@ project(PokerEquityTest
 	VERSION 1.0
 	LANGUAGES C CXX)
 
-add_library(PokerEval STATIC
-	Poker.PokerEval/lib/combinations.c
-	Poker.PokerEval/lib/deck.c
-	Poker.PokerEval/lib/deck_astud.c
-	Poker.PokerEval/lib/deck_joker.c
-	Poker.PokerEval/lib/deck_std.c
-	Poker.PokerEval/lib/enumerate.c
-	Poker.PokerEval/lib/enumord.c
-	Poker.PokerEval/lib/evx.c
-	Poker.PokerEval/lib/lowball.c
-	Poker.PokerEval/lib/rules_astud.c
-	Poker.PokerEval/lib/rules_joker.c
-	Poker.PokerEval/lib/rules_std.c
-	Poker.PokerEval/lib/t_astudcardmasks.c
-	Poker.PokerEval/lib/t_botcard.c
-	Poker.PokerEval/lib/t_botfivecards.c
-	Poker.PokerEval/lib/t_botfivecardsj.c
-	Poker.PokerEval/lib/t_cardmasks.c
-	Poker.PokerEval/lib/t_evx_flushcards.c
-	Poker.PokerEval/lib/t_evx_pairval.c
-	Poker.PokerEval/lib/t_evx_strval.c
-	Poker.PokerEval/lib/t_evx_tripsval.c
-	Poker.PokerEval/lib/t_jokercardmasks.c
-	Poker.PokerEval/lib/t_jokerstraight.c
-	Poker.PokerEval/lib/t_maskrank.c
-	Poker.PokerEval/lib/t_nbits.c
-	Poker.PokerEval/lib/t_nbitsandstr.c
-	Poker.PokerEval/lib/t_straight.c
-	Poker.PokerEval/lib/t_topbit.c
-	Poker.PokerEval/lib/t_topcard.c
-	Poker.PokerEval/lib/t_topfivebits.c
-	Poker.PokerEval/lib/t_topfivecards.c
-	Poker.PokerEval/lib/t_toptwobits.c)
-target_include_directories(PokerEval PRIVATE Poker.PokerEval/include)
-set_target_properties(PokerEval PROPERTIES LINKER_LANGUAGE C)
-set_target_properties(PokerEval PROPERTIES POSITION_INDEPENDENT_CODE ON)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/Poker.PokerEval/)
 
 add_library(PokerEquity SHARED
 	Poker.Equity/AgnosticHand.cpp

--- a/Poker.PokerEval/CMakeLists.txt
+++ b/Poker.PokerEval/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 
 project(PokerEquity
-	VERSION 1.0
+	VERSION 138.0
 	LANGUAGES C CXX)
 
 

--- a/Poker.PokerEval/CMakeLists.txt
+++ b/Poker.PokerEval/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(PokerEquity
+	VERSION 1.0
+	LANGUAGES C CXX)
+
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/lib/CMakeLists.txt)
+include(${CMAKE_CURRENT_SOURCE_DIR}/tests/CMakeLists.txt)
+include(${CMAKE_CURRENT_SOURCE_DIR}/examples/CMakeLists.txt)
+
+
+
+
+

--- a/Poker.PokerEval/COPYING
+++ b/Poker.PokerEval/COPYING
@@ -1,285 +1,626 @@
-		    GNU GENERAL PUBLIC LICENSE
-		       Version 2, June 1991
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-			    Preamble
+                            Preamble
 
-  The licenses for most software are designed to take away your
-freedom to share and change it.  By contrast, the GNU General Public
-License is intended to guarantee your freedom to share and change free
-software--to make sure the software is free for all its users.  This
-General Public License applies to most of the Free Software
-Foundation's software and to any other program whose authors commit to
-using it.  (Some other Free Software Foundation software is covered by
-the GNU Library General Public License instead.)  You can apply it to
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
 your programs, too.
 
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
-this service if you wish), that you receive source code or can get it
-if you want it, that you can change the software or use pieces of it
-in new free programs; and that you know you can do these things.
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-  To protect your rights, we need to make restrictions that forbid
-anyone to deny you these rights or to ask you to surrender the rights.
-These restrictions translate to certain responsibilities for you if you
-distribute copies of the software, or if you modify it.
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
 
   For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must give the recipients all the rights that
-you have.  You must make sure that they, too, receive or can get the
-source code.  And you must show them these terms so they know their
-rights.
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
 
-  We protect your rights with two steps: (1) copyright the software, and
-(2) offer you this license which gives you legal permission to copy,
-distribute and/or modify the software.
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
 
-  Also, for each author's protection and ours, we want to make certain
-that everyone understands that there is no warranty for this free
-software.  If the software is modified by someone else and passed on, we
-want its recipients to know that what they have is not the original, so
-that any problems introduced by others will not reflect on the original
-authors' reputations.
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
 
-  Finally, any free program is threatened constantly by software
-patents.  We wish to avoid the danger that redistributors of a free
-program will individually obtain patent licenses, in effect making the
-program proprietary.  To prevent this, we have made it clear that any
-patent must be licensed for everyone's free use or not licensed at all.
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
-
-		    GNU GENERAL PUBLIC LICENSE
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
-  0. This License applies to any program or other work which contains
-a notice placed by the copyright holder saying it may be distributed
-under the terms of this General Public License.  The "Program", below,
-refers to any such program or work, and a "work based on the Program"
-means either the Program or any derivative work under copyright law:
-that is to say, a work containing the Program or a portion of it,
-either verbatim or with modifications and/or translated into another
-language.  (Hereinafter, translation is included without limitation in
-the term "modification".)  Each licensee is addressed as "you".
+                       TERMS AND CONDITIONS
 
-Activities other than copying, distribution and modification are not
-covered by this License; they are outside its scope.  The act of
-running the Program is not restricted, and the output from the Program
-is covered only if its contents constitute a work based on the
-Program (independent of having been made by running the Program).
-Whether that is true depends on what the Program does.
+  0. Definitions.
 
-  1. You may copy and distribute verbatim copies of the Program's
-source code as you receive it, in any medium, provided that you
-conspicuously and appropriately publish on each copy an appropriate
-copyright notice and disclaimer of warranty; keep intact all the
-notices that refer to this License and to the absence of any warranty;
-and give any other recipients of the Program a copy of this License
-along with the Program.
+  "This License" refers to version 3 of the GNU General Public License.
 
-You may charge a fee for the physical act of transferring a copy, and
-you may at your option offer warranty protection in exchange for a fee.
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-  2. You may modify your copy or copies of the Program or any portion
-of it, thus forming a work based on the Program, and copy and
-distribute such modifications or work under the terms of Section 1
-above, provided that you also meet all of these conditions:
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-    a) You must cause the modified files to carry prominent notices
-    stating that you changed the files and the date of any change.
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-    b) You must cause any work that you distribute or publish, that in
-    whole or in part contains or is derived from the Program or any
-    part thereof, to be licensed as a whole at no charge to all third
-    parties under the terms of this License.
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-    c) If the modified program normally reads commands interactively
-    when run, you must cause it, when started running for such
-    interactive use in the most ordinary way, to print or display an
-    announcement including an appropriate copyright notice and a
-    notice that there is no warranty (or else, saying that you provide
-    a warranty) and that users may redistribute the program under
-    these conditions, and telling the user how to view a copy of this
-    License.  (Exception: if the Program itself is interactive but
-    does not normally print such an announcement, your work based on
-    the Program is not required to print an announcement.)
-
-These requirements apply to the modified work as a whole.  If
-identifiable sections of that work are not derived from the Program,
-and can be reasonably considered independent and separate works in
-themselves, then this License, and its terms, do not apply to those
-sections when you distribute them as separate works.  But when you
-distribute the same sections as part of a whole which is a work based
-on the Program, the distribution of the whole must be on the terms of
-this License, whose permissions for other licensees extend to the
-entire whole, and thus to each and every part regardless of who wrote it.
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-Thus, it is not the intent of this section to claim rights or contest
-your rights to work written entirely by you; rather, the intent is to
-exercise the right to control the distribution of derivative or
-collective works based on the Program.
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-In addition, mere aggregation of another work not based on the Program
-with the Program (or with a work based on the Program) on a volume of
-a storage or distribution medium does not bring the other work under
-the scope of this License.
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-  3. You may copy and distribute the Program (or a work based on it,
-under Section 2) in object code or executable form under the terms of
-Sections 1 and 2 above provided that you also do one of the following:
+  1. Source Code.
 
-    a) Accompany it with the complete corresponding machine-readable
-    source code, which must be distributed under the terms of Sections
-    1 and 2 above on a medium customarily used for software interchange; or,
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-    b) Accompany it with a written offer, valid for at least three
-    years, to give any third party, for a charge no more than your
-    cost of physically performing source distribution, a complete
-    machine-readable copy of the corresponding source code, to be
-    distributed under the terms of Sections 1 and 2 above on a medium
-    customarily used for software interchange; or,
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
 
-    c) Accompany it with the information you received as to the offer
-    to distribute corresponding source code.  (This alternative is
-    allowed only for noncommercial distribution and only if you
-    received the program in object code or executable form with such
-    an offer, in accord with Subsection b above.)
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
 
-The source code for a work means the preferred form of the work for
-making modifications to it.  For an executable work, complete source
-code means all the source code for all modules it contains, plus any
-associated interface definition files, plus the scripts used to
-control compilation and installation of the executable.  However, as a
-special exception, the source code distributed need not include
-anything that is normally distributed (in either source or binary
-form) with the major components (compiler, kernel, and so on) of the
-operating system on which the executable runs, unless that component
-itself accompanies the executable.
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
 
-If distribution of executable or object code is made by offering
-access to copy from a designated place, then offering equivalent
-access to copy the source code from the same place counts as
-distribution of the source code, even though third parties are not
-compelled to copy the source along with the object code.
-
-  4. You may not copy, modify, sublicense, or distribute the Program
-except as expressly provided under this License.  Any attempt
-otherwise to copy, modify, sublicense or distribute the Program is
-void, and will automatically terminate your rights under this License.
-However, parties who have received copies, or rights, from you under
-this License will not have their licenses terminated so long as such
-parties remain in full compliance.
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
 
-  5. You are not required to accept this License, since you have not
-signed it.  However, nothing else grants you permission to modify or
-distribute the Program or its derivative works.  These actions are
-prohibited by law if you do not accept this License.  Therefore, by
-modifying or distributing the Program (or any work based on the
-Program), you indicate your acceptance of this License to do so, and
-all its terms and conditions for copying, distributing or modifying
-the Program or works based on it.
+  The Corresponding Source for a work in source code form is that
+same work.
 
-  6. Each time you redistribute the Program (or any work based on the
-Program), the recipient automatically receives a license from the
-original licensor to copy, distribute or modify the Program subject to
-these terms and conditions.  You may not impose any further
-restrictions on the recipients' exercise of the rights granted herein.
-You are not responsible for enforcing compliance by third parties to
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
 this License.
 
-  7. If, as a consequence of a court judgment or allegation of patent
-infringement or for any other reason (not limited to patent issues),
-conditions are imposed on you (whether by court order, agreement or
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot
-distribute so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you
-may not distribute the Program at all.  For example, if a patent
-license would not permit royalty-free redistribution of the Program by
-all those who receive copies directly or indirectly through you, then
-the only way you could satisfy both it and this License would be to
-refrain entirely from distribution of the Program.
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
 
-If any portion of this section is held invalid or unenforceable under
-any particular circumstance, the balance of the section is intended to
-apply and the section as a whole is intended to apply in other
-circumstances.
+  13. Use with the GNU Affero General Public License.
 
-It is not the purpose of this section to induce you to infringe any
-patents or other property right claims or to contest validity of any
-such claims; this section has the sole purpose of protecting the
-integrity of the free software distribution system, which is
-implemented by public license practices.  Many people have made
-generous contributions to the wide range of software distributed
-through that system in reliance on consistent application of that
-system; it is up to the author/donor to decide if he or she is willing
-to distribute software through any other system and a licensee cannot
-impose that choice.
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
 
-This section is intended to make thoroughly clear what is believed to
-be a consequence of the rest of this License.
-
-  8. If the distribution and/or use of the Program is restricted in
-certain countries either by patents or by copyrighted interfaces, the
-original copyright holder who places the Program under this License
-may add an explicit geographical distribution limitation excluding
-those countries, so that distribution is permitted only in or among
-countries not thus excluded.  In such case, this License incorporates
-the limitation as if written in the body of this License.
+  14. Revised Versions of this License.
 
-  9. The Free Software Foundation may publish revised and/or new versions
-of the General Public License from time to time.  Such new versions will
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
 be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
-Each version is given a distinguishing version number.  If the Program
-specifies a version number of this License which applies to it and "any
-later version", you have the option of following the terms and conditions
-either of that version or of any later version published by the Free
-Software Foundation.  If the Program does not specify a version number of
-this License, you may choose any version ever published by the Free Software
-Foundation.
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
 
-  10. If you wish to incorporate parts of the Program into other free
-programs whose distribution conditions are different, write to the author
-to ask for permission.  For software which is copyrighted by the Free
-Software Foundation, write to the Free Software Foundation; we sometimes
-make exceptions for this.  Our decision will be guided by the two goals
-of preserving the free status of all derivatives of our free software and
-of promoting the sharing and reuse of software generally.
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
 
-			    NO WARRANTY
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
 
-  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
-FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
-OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
-PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
-OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
-TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
-PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
-REPAIR OR CORRECTION.
+  15. Disclaimer of Warranty.
 
-  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
-REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
-INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
-OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
-TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
-YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
-PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGES.
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
 
-		     END OF TERMS AND CONDITIONS
-
-	    How to Apply These Terms to Your New Programs
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
 
   If you develop a new program, and you want it to be of the greatest
 possible use to the public, the best way to achieve this is to make it
@@ -287,15 +628,15 @@ free software which everyone can redistribute and change under these terms.
 
   To do so, attach the following notices to the program.  It is safest
 to attach them to the start of each source file to most effectively
-convey the exclusion of warranty; and each file should have at least
+state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     <one line to give the program's name and a brief idea of what it does.>
     Copyright (C) <year>  <name of author>
 
-    This program is free software; you can redistribute it and/or modify
+    This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
+    the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
@@ -304,37 +645,30 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-If the program is interactive, make it output a short notice like this
-when it starts in an interactive mode:
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
 
-    Gnomovision version 69, Copyright (C) year  name of author
-    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
 
 The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, the commands you use may
-be called something other than `show w' and `show c'; they could even be
-mouse-clicks or menu items--whatever suits your program.
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
 
-You should also get your employer (if you work as a programmer) or your
-school, if any, to sign a "copyright disclaimer" for the program, if
-necessary.  Here is a sample; alter the names:
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
 
-  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
-  `Gnomovision' (which makes passes at compilers) written by James Hacker.
-
-  <signature of Ty Coon>, 1 April 1989
-  Ty Coon, President of Vice
-
-This General Public License does not permit incorporating your program into
-proprietary programs.  If your program is a subroutine library, you may
-consider it more useful to permit linking proprietary applications with the
-library.  If this is what you want to do, use the GNU Library General
-Public License instead of this License.
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/Poker.PokerEval/ChangeLog
+++ b/Poker.PokerEval/ChangeLog
@@ -1,7 +1,107 @@
-2007-12-03  Loic Dachary <loic@dachary.org>
+2010-09-02  Loic Dachary  <loic@dachary.org>
+
+	* Release 138.0
+
+	* debian/rules: debian/stamp-autotools-configure replaces
+	  config.status target in newer cdbs
+	* debian/rules: debian/stamp-autotools-configure replaces
+	  config.status target in newer cdbs
+	* debian/control, debian/rules: automake1.9 is not longer required
+	* Makefile.am, examples/Makefile.am: manually expand wild cards in
+	  variables for POSIX conformance
+	* include/deck_undef.h: add missing undefs as suggested by
+	  http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=488747
+	* configure.ac: add AM_PROG_CC_C_O to allow per object flags
+	* ChangeLog, NEWS, configure.ac: bump to version 138.0
+	* debian/changelog, debian/libpoker-eval-dev.docs: clear spurious
+	  example file
+
+2010-02-10  Loic Dachary <loic@dachary.org>
+
+	* Release 137.0
+
+	* include/enumerate.h: Apply 64bits fix from
+	  https://bugs.launchpad.net/ubuntu/+source/pypoker-eval/+bug/508739/comments/2
+
+2009-10-12  Loic Dachary <loic@dachary.org>
+
+	* tests/bug1823: bash4 patch from Ralf Corsepius via Christopher
+	  Stone
+
+2009-08-12  Loic Dachary <loic@dachary.org>
+
+	* ChangeLog, NEWS, configure.ac, debian/changelog: Bump to version
+	  137.0
+
+2009-07-09  Loic Dachary <loic@dachary.org>
+
+	* Release 136.0
+
+	* debian/rules: Compensate for the case where autoconf has a
+	  compatibility problem with libtoolize that can be solved by
+	  copying the libtool script directly instead of going thru
+	  autoconf ( shows as an error of the type libtool: line 821:
+	  X--tag=CC: command not found etc.).
+
+2009-07-07  Loic Dachary <loic@dachary.org>
+
+	* lib/evx_generate.c: move misplaced parenthesis
+	* configure.ac, include/poker_wrapper.h, lib/Makefile.am,
+	  lib/deck.c, lib/evx_generate.c, lib/poker_wrapper.c,
+	  tests/enumtest3.c, tests/poker_wrapper.c: Mac build patches,
+	  courtesy Clifford T. Matthews
+
+2009-01-14  Loic Dachary <loic@dachary.org>
+
+	* include/deck.h: Deck_cardString & Deck_printCard must provide
+	  &CurDeck instead of CurDeck
+
+2009-01-02  Loic Dachary <loic@dachary.org>
+
+	* include/enumerate.h, lib/combinations.c, lib/evx_generate.c:
+	  replace exit() with return because it is bad practice for a
+	  library to call
+	  http://xulchris.fedorapeople.org/poker-eval-135.0-exit.patch
+
+2008-12-27  Loic Dachary  <loic@dachary.org>
+
+	* configure.ac: remove AC_PROG_CXX because c++ has nothing to do
+	  with poker-eval
+	* Makefile.am: Add GPLv3 and GPLv3-assent.txt to the distribution
+	* LICENSE: update copyrights. Igor was removed because his
+	  contribution was made under contract for Mekensleep who has the
+	  corresponding copyright.
+	* ChangeLog, NEWS, configure.ac, debian/changelog: bump to version
+	  136
+
+2008-12-02  Bradley M. Kuhn  <bkuhn@ebb.org>
 
 	* Release 135.0
 
+	* configure.ac (AC_PROG_CPP): AC_PROG_CPP appears to be
+	deprecated; switched to AC_PROG_CXX
+
+2008-11-17  Loic Dachary <loic@dachary.org>
+
+	* lib/md5.h, lib/md5c.c: get rid of unused md5 implementation under
+	  a proprietary license
+
+2008-04-02  Loic Dachary <loic@dachary.org>
+
+	* GPLv3.txt: 2008: license GPLv3+ added to poker-eval
+
+2008-03-21  Loic Dachary <loic@dachary.org>
+
+	* include/deck_astud.h, include/deck_joker.h, include/deck_std.h,
+	  lib/deck.c: Fix overflow as suggested by W. None
+	  <miathan6@gmail.com>
+
+2007-12-03  Loic Dachary <loic@dachary.org>
+
+	* tests/Makefile.am: move razz.c to extra dist
+	* Makefile.am: add csharp/TODO to distribution
+	* tests/Makefile.am: don't do razz for now
+	* tests/Makefile.am: bug1823 in EXTRA_DIST
 	* tests/razz.c: remove duplicate declaration
 	* tests/run.in: run all bugs scripts as standalone
 	* tests/bug1823: Run thru all poker-eval/lib/enumerate.c #define
@@ -10,11 +110,75 @@
 	* tests/Makefile.am: bug1823 test case
 	* lib/enumerate.c: compare double with > 0.99 instead of 1
 
+2007-06-23  jvivenot
+
+	* java/README: removed
+
+2007-06-19  jvivenot
+
+	* java/org/pokersource/util/test/NestedLoopEnumerationTest.java:
+	  enum package name (keyword) => enumerate
+	* java/org/pokersource/enum: enum package name (keyword) =>
+	  enumerate
+	* java/org/pokersource/enumerate/BaseHandGroup.java,
+	  java/org/pokersource/enumerate/BeliefVector.java,
+	  java/org/pokersource/enumerate/Enumerate.java,
+	  java/org/pokersource/enumerate/EnumerateImp.c,
+	  java/org/pokersource/enumerate/HandGroup.java,
+	  java/org/pokersource/enumerate/HandMatchup.java,
+	  java/org/pokersource/enumerate/HandValuation.java,
+	  java/org/pokersource/enumerate/HoldemAbdulGroup.java,
+	  java/org/pokersource/enumerate/HoldemAtomicGroup.java,
+	  java/org/pokersource/enumerate/HoldemBeliefVector.java,
+	  java/org/pokersource/enumerate/HoldemCanonGroup.java,
+	  java/org/pokersource/enumerate/HoldemHandGroup.java,
+	  java/org/pokersource/enumerate/HoldemHandGroupFactory.java,
+	  java/org/pokersource/enumerate/HoldemHandOrdering.java,
+	  java/org/pokersource/enumerate/HoldemSMGroup.java,
+	  java/org/pokersource/enumerate/HoldemThresholdGroup.java,
+	  java/org/pokersource/enumerate/HoldemUniversalGroup.java,
+	  java/org/pokersource/enumerate/MatchupOutcome.java,
+	  java/org/pokersource/enumerate/RankOrdering.java,
+	  java/org/pokersource/enumerate/SAIE.java,
+	  java/org/pokersource/enumerate/SAIEMain.java,
+	  java/org/pokersource/enumerate/ThresholdHandGroup.java,
+	  java/org/pokersource/enumerate/package.html,
+	  java/org/pokersource/enumerate/test,
+	  java/org/pokersource/enumerate/test/.cvsignore,
+	  java/org/pokersource/enumerate/test/AllTests.java,
+	  java/org/pokersource/enumerate/test/EnumerateTest.java,
+	  java/org/pokersource/enumerate/test/HandMatchupTest.java,
+	  java/org/pokersource/enumerate/test/HandValuationTest.java,
+	  java/org/pokersource/enumerate/test/HoldemAbdulGroupTest.java,
+	  java/org/pokersource/enumerate/test/HoldemAtomicGroupTest.java,
+	  java/org/pokersource/enumerate/test/HoldemBeliefVectorTest.java,
+	  java/org/pokersource/enumerate/test/HoldemCanonGroupTest.java,
+	  java/org/pokersource/enumerate/test/HoldemHandGroupFactoryTest.java,
+	  java/org/pokersource/enumerate/test/HoldemHandOrderingTest.java,
+	  java/org/pokersource/enumerate/test/HoldemSMGroupTest.java,
+	  java/org/pokersource/enumerate/test/HoldemThresholdGroupTest.java,
+	  java/org/pokersource/enumerate/test/HoldemUniversalGroupTest.java,
+	  java/org/pokersource/enumerate/test/SAIETest.java: enum package
+	  name (keyword) => enumerate
+	* java/org/pokersource/enumerate: enum package name (keyword) =>
+	  enumerate
+	* java/org/pokersource/AllTests.java: enum package name (keyword)
+	  => enumerate
+
+2007-06-19  Loic Dachary <loic@dachary.org>
+
+	* java/README: Note about building with jdk-1.4.
+
 2007-05-16  Loic Dachary <loic@dachary.org>
 
+	* NEWS, debian/changelog: Version bump.
 	* tests/Makefile.am, tests/razz.c, tests/run.in: Add fail test for
 	  razz.
 	* configure.ac: Remove complex GCC flags in favor of simpler one.
+
+2006-12-19  Johan Euphrosine <proppy@aminche.com>
+
+	* Makefile.am, fink, fink/libpoker-eval.info: added fink package
 
 2006-12-17  Loic Dachary  <loic@dachary.org>
 

--- a/Poker.PokerEval/INSTALL
+++ b/Poker.PokerEval/INSTALL
@@ -1,16 +1,25 @@
 Installation Instructions
 *************************
 
-Copyright (C) 1994, 1995, 1996, 1999, 2000, 2001, 2002, 2004, 2005 Free
-Software Foundation, Inc.
+Copyright (C) 1994, 1995, 1996, 1999, 2000, 2001, 2002, 2004, 2005,
+2006, 2007, 2008, 2009 Free Software Foundation, Inc.
 
-This file is free documentation; the Free Software Foundation gives
-unlimited permission to copy, distribute and modify it.
+   Copying and distribution of this file, with or without modification,
+are permitted in any medium without royalty provided the copyright
+notice and this notice are preserved.  This file is offered as-is,
+without warranty of any kind.
 
 Basic Installation
 ==================
 
-These are generic installation instructions.
+   Briefly, the shell commands `./configure; make; make install' should
+configure, build, and install this package.  The following
+more-detailed instructions are generic; see the `README' file for
+instructions specific to this package.  Some packages provide this
+`INSTALL' file but do not implement all of the features documented
+below.  The lack of an optional feature in a given package is not
+necessarily a bug.  More recommendations for GNU packages can be found
+in *note Makefile Conventions: (standards)Makefile Conventions.
 
    The `configure' shell script attempts to guess correct values for
 various system-dependent variables used during compilation.  It uses
@@ -23,9 +32,9 @@ debugging `configure').
 
    It can also use an optional file (typically called `config.cache'
 and enabled with `--cache-file=config.cache' or simply `-C') that saves
-the results of its tests to speed up reconfiguring.  (Caching is
+the results of its tests to speed up reconfiguring.  Caching is
 disabled by default to prevent problems with accidental use of stale
-cache files.)
+cache files.
 
    If you need to do unusual things to compile the package, please try
 to figure out how `configure' could check whether to do them, and mail
@@ -35,30 +44,37 @@ some point `config.cache' contains results you don't want to keep, you
 may remove or edit it.
 
    The file `configure.ac' (or `configure.in') is used to create
-`configure' by a program called `autoconf'.  You only need
-`configure.ac' if you want to change it or regenerate `configure' using
-a newer version of `autoconf'.
+`configure' by a program called `autoconf'.  You need `configure.ac' if
+you want to change it or regenerate `configure' using a newer version
+of `autoconf'.
 
-The simplest way to compile this package is:
+   The simplest way to compile this package is:
 
   1. `cd' to the directory containing the package's source code and type
-     `./configure' to configure the package for your system.  If you're
-     using `csh' on an old version of System V, you might need to type
-     `sh ./configure' instead to prevent `csh' from trying to execute
-     `configure' itself.
+     `./configure' to configure the package for your system.
 
-     Running `configure' takes awhile.  While running, it prints some
-     messages telling which features it is checking for.
+     Running `configure' might take a while.  While running, it prints
+     some messages telling which features it is checking for.
 
   2. Type `make' to compile the package.
 
   3. Optionally, type `make check' to run any self-tests that come with
-     the package.
+     the package, generally using the just-built uninstalled binaries.
 
   4. Type `make install' to install the programs and any data files and
-     documentation.
+     documentation.  When installing into a prefix owned by root, it is
+     recommended that the package be configured and built as a regular
+     user, and only the `make install' phase executed with root
+     privileges.
 
-  5. You can remove the program binaries and object files from the
+  5. Optionally, type `make installcheck' to repeat any self-tests, but
+     this time using the binaries in their final installed location.
+     This target does not install anything.  Running this target as a
+     regular user, particularly if the prior `make install' required
+     root privileges, verifies that the installation completed
+     correctly.
+
+  6. You can remove the program binaries and object files from the
      source code directory by typing `make clean'.  To also remove the
      files that `configure' created (so you can compile the package for
      a different kind of computer), type `make distclean'.  There is
@@ -67,45 +83,69 @@ The simplest way to compile this package is:
      all sorts of other programs in order to regenerate files that came
      with the distribution.
 
+  7. Often, you can also type `make uninstall' to remove the installed
+     files again.  In practice, not all packages have tested that
+     uninstallation works correctly, even though it is required by the
+     GNU Coding Standards.
+
+  8. Some packages, particularly those that use Automake, provide `make
+     distcheck', which can by used by developers to test that all other
+     targets like `make install' and `make uninstall' work correctly.
+     This target is generally not run by end users.
+
 Compilers and Options
 =====================
 
-Some systems require unusual options for compilation or linking that the
-`configure' script does not know about.  Run `./configure --help' for
-details on some of the pertinent environment variables.
+   Some systems require unusual options for compilation or linking that
+the `configure' script does not know about.  Run `./configure --help'
+for details on some of the pertinent environment variables.
 
    You can give `configure' initial values for configuration parameters
 by setting variables in the command line or in the environment.  Here
 is an example:
 
-     ./configure CC=c89 CFLAGS=-O2 LIBS=-lposix
+     ./configure CC=c99 CFLAGS=-g LIBS=-lposix
 
    *Note Defining Variables::, for more details.
 
 Compiling For Multiple Architectures
 ====================================
 
-You can compile the package for more than one kind of computer at the
+   You can compile the package for more than one kind of computer at the
 same time, by placing the object files for each architecture in their
-own directory.  To do this, you must use a version of `make' that
-supports the `VPATH' variable, such as GNU `make'.  `cd' to the
+own directory.  To do this, you can use GNU `make'.  `cd' to the
 directory where you want the object files and executables to go and run
 the `configure' script.  `configure' automatically checks for the
-source code in the directory that `configure' is in and in `..'.
+source code in the directory that `configure' is in and in `..'.  This
+is known as a "VPATH" build.
 
-   If you have to use a `make' that does not support the `VPATH'
-variable, you have to compile the package for one architecture at a
-time in the source code directory.  After you have installed the
-package for one architecture, use `make distclean' before reconfiguring
-for another architecture.
+   With a non-GNU `make', it is safer to compile the package for one
+architecture at a time in the source code directory.  After you have
+installed the package for one architecture, use `make distclean' before
+reconfiguring for another architecture.
+
+   On MacOS X 10.5 and later systems, you can create libraries and
+executables that work on multiple system types--known as "fat" or
+"universal" binaries--by specifying multiple `-arch' options to the
+compiler but only a single `-arch' option to the preprocessor.  Like
+this:
+
+     ./configure CC="gcc -arch i386 -arch x86_64 -arch ppc -arch ppc64" \
+                 CXX="g++ -arch i386 -arch x86_64 -arch ppc -arch ppc64" \
+                 CPP="gcc -E" CXXCPP="g++ -E"
+
+   This is not guaranteed to produce working output in all cases, you
+may have to build one architecture at a time and combine the results
+using the `lipo' tool if you have problems.
 
 Installation Names
 ==================
 
-By default, `make install' installs the package's commands under
+   By default, `make install' installs the package's commands under
 `/usr/local/bin', include files under `/usr/local/include', etc.  You
 can specify an installation prefix other than `/usr/local' by giving
-`configure' the option `--prefix=PREFIX'.
+`configure' the option `--prefix=PREFIX', where PREFIX must be an
+absolute file name.
 
    You can specify separate installation prefixes for
 architecture-specific files and architecture-independent files.  If you
@@ -116,16 +156,47 @@ Documentation and other data files still use the regular prefix.
    In addition, if you use an unusual directory layout you can give
 options like `--bindir=DIR' to specify different values for particular
 kinds of files.  Run `configure --help' for a list of the directories
-you can set and what kinds of files go in them.
+you can set and what kinds of files go in them.  In general, the
+default for these options is expressed in terms of `${prefix}', so that
+specifying just `--prefix' will affect all of the other directory
+specifications that were not explicitly provided.
+
+   The most portable way to affect installation locations is to pass the
+correct locations to `configure'; however, many packages provide one or
+both of the following shortcuts of passing variable assignments to the
+`make install' command line to change installation locations without
+having to reconfigure or recompile.
+
+   The first method involves providing an override variable for each
+affected directory.  For example, `make install
+prefix=/alternate/directory' will choose an alternate location for all
+directory configuration variables that were expressed in terms of
+`${prefix}'.  Any directories that were specified during `configure',
+but not in terms of `${prefix}', must each be overridden at install
+time for the entire installation to be relocated.  The approach of
+makefile variable overrides for each directory variable is required by
+the GNU Coding Standards, and ideally causes no recompilation.
+However, some platforms have known limitations with the semantics of
+shared libraries that end up requiring recompilation when using this
+method, particularly noticeable in packages that use GNU Libtool.
+
+   The second method involves providing the `DESTDIR' variable.  For
+example, `make install DESTDIR=/alternate/directory' will prepend
+`/alternate/directory' before all installation names.  The approach of
+`DESTDIR' overrides is not required by the GNU Coding Standards, and
+does not work on platforms that have drive letters.  On the other hand,
+it does better at avoiding recompilation issues, and works well even
+when some directory options were not specified in terms of `${prefix}'
+at `configure' time.
+
+Optional Features
+=================
 
    If the package supports it, you can cause programs to be installed
 with an extra prefix or suffix on their names by giving `configure' the
 option `--program-prefix=PREFIX' or `--program-suffix=SUFFIX'.
 
-Optional Features
-=================
-
-Some packages pay attention to `--enable-FEATURE' options to
+   Some packages pay attention to `--enable-FEATURE' options to
 `configure', where FEATURE indicates an optional part of the package.
 They may also pay attention to `--with-PACKAGE' options, where PACKAGE
 is something like `gnu-as' or `x' (for the X Window System).  The
@@ -137,14 +208,53 @@ find the X include and library files automatically, but if it doesn't,
 you can use the `configure' options `--x-includes=DIR' and
 `--x-libraries=DIR' to specify their locations.
 
+   Some packages offer the ability to configure how verbose the
+execution of `make' will be.  For these packages, running `./configure
+--enable-silent-rules' sets the default to minimal output, which can be
+overridden with `make V=1'; while running `./configure
+--disable-silent-rules' sets the default to verbose, which can be
+overridden with `make V=0'.
+
+Particular systems
+==================
+
+   On HP-UX, the default C compiler is not ANSI C compatible.  If GNU
+CC is not installed, it is recommended to use the following options in
+order to use an ANSI C compiler:
+
+     ./configure CC="cc -Ae -D_XOPEN_SOURCE=500"
+
+and if that doesn't work, install pre-built binaries of GCC for HP-UX.
+
+   On OSF/1 a.k.a. Tru64, some versions of the default C compiler cannot
+parse its `<wchar.h>' header file.  The option `-nodtk' can be used as
+a workaround.  If GNU CC is not installed, it is therefore recommended
+to try
+
+     ./configure CC="cc"
+
+and if that doesn't work, try
+
+     ./configure CC="cc -nodtk"
+
+   On Solaris, don't put `/usr/ucb' early in your `PATH'.  This
+directory contains several dysfunctional programs; working variants of
+these programs are available in `/usr/bin'.  So, if you need `/usr/ucb'
+in your `PATH', put it _after_ `/usr/bin'.
+
+   On Haiku, software installed for all users goes in `/boot/common',
+not `/usr/local'.  It is recommended to use the following options:
+
+     ./configure --prefix=/boot/common
+
 Specifying the System Type
 ==========================
 
-There may be some features `configure' cannot figure out automatically,
-but needs to determine by the type of machine the package will run on.
-Usually, assuming the package is built to be run on the _same_
-architectures, `configure' can figure that out, but if it prints a
-message saying it cannot guess the machine type, give it the
+   There may be some features `configure' cannot figure out
+automatically, but needs to determine by the type of machine the package
+will run on.  Usually, assuming the package is built to be run on the
+_same_ architectures, `configure' can figure that out, but if it prints
+a message saying it cannot guess the machine type, give it the
 `--build=TYPE' option.  TYPE can either be a short name for the system
 type, such as `sun4', or a canonical name which has the form:
 
@@ -152,7 +262,8 @@ type, such as `sun4', or a canonical name which has the form:
 
 where SYSTEM can have one of these forms:
 
-     OS KERNEL-OS
+     OS
+     KERNEL-OS
 
    See the file `config.sub' for the possible values of each field.  If
 `config.sub' isn't included in this package, then this package doesn't
@@ -170,9 +281,9 @@ eventually be run) with `--host=TYPE'.
 Sharing Defaults
 ================
 
-If you want to set default values for `configure' scripts to share, you
-can create a site shell script called `config.site' that gives default
-values for variables like `CC', `cache_file', and `prefix'.
+   If you want to set default values for `configure' scripts to share,
+you can create a site shell script called `config.site' that gives
+default values for variables like `CC', `cache_file', and `prefix'.
 `configure' looks for `PREFIX/share/config.site' if it exists, then
 `PREFIX/etc/config.site' if it exists.  Or, you can set the
 `CONFIG_SITE' environment variable to the location of the site script.
@@ -181,7 +292,7 @@ A warning: not all `configure' scripts look for a site script.
 Defining Variables
 ==================
 
-Variables not defined in a site shell script can be set in the
+   Variables not defined in a site shell script can be set in the
 environment passed to `configure'.  However, some packages may run
 configure again during the build, and the customized values of these
 variables may be lost.  In order to avoid this problem, you should set
@@ -190,21 +301,29 @@ them in the `configure' command line, using `VAR=value'.  For example:
      ./configure CC=/usr/local2/bin/gcc
 
 causes the specified `gcc' to be used as the C compiler (unless it is
-overridden in the site shell script).  Here is a another example:
+overridden in the site shell script).
 
-     /bin/bash ./configure CONFIG_SHELL=/bin/bash
+Unfortunately, this technique does not work for `CONFIG_SHELL' due to
+an Autoconf bug.  Until the bug is fixed you can use this workaround:
 
-Here the `CONFIG_SHELL=/bin/bash' operand causes subsequent
-configuration-related scripts to be executed by `/bin/bash'.
+     CONFIG_SHELL=/bin/bash /bin/bash ./configure CONFIG_SHELL=/bin/bash
 
 `configure' Invocation
 ======================
 
-`configure' recognizes the following options to control how it operates.
+   `configure' recognizes the following options to control how it
+operates.
 
 `--help'
 `-h'
-     Print a summary of the options to `configure', and exit.
+     Print a summary of all of the options to `configure', and exit.
+
+`--help=short'
+`--help=recursive'
+     Print a summary of the options unique to this package's
+     `configure', and exit.  The `short' variant lists options used
+     only in the top level, while the `recursive' variant lists options
+     also present in any nested packages.
 
 `--version'
 `-V'
@@ -230,6 +349,16 @@ configuration-related scripts to be executed by `/bin/bash'.
 `--srcdir=DIR'
      Look for the package's source code in directory DIR.  Usually
      `configure' can determine that directory automatically.
+
+`--prefix=DIR'
+     Use DIR as the installation prefix.  *note Installation Names::
+     for more details, including other options available for fine-tuning
+     the installation locations.
+
+`--no-create'
+`-n'
+     Run the configure checks, but stop before creating any output
+     files.
 
 `configure' also accepts some other, not widely useful, options.  Run
 `configure --help' for more details.

--- a/Poker.PokerEval/Makefile.am
+++ b/Poker.PokerEval/Makefile.am
@@ -1,4 +1,5 @@
 #
+# Copyright (C) 2004-2010 Loic Dachary <loic@dachary.org>
 # Copyright (C) 2004-2006 Mekensleep
 #
 # Mekensleep
@@ -6,25 +7,28 @@
 # 75004 Paris
 #       licensing@mekensleep.com
 #
-#  This package is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; version 2 dated June, 1991.
+# This program gives you software freedom; you can copy, convey,
+# propagate, redistribute and/or modify this program under the terms of
+# the GNU General Public License (GPL) as published by the Free Software
+# Foundation (FSF), either version 3 of the License, or (at your option)
+# any later version of the GPL published by the FSF.
 #
-#  This package is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
 #
-#  You should have received a copy of the GNU General Public License
-#  along with this package; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
-#  MA 02110-1301, USA.
+# You should have received a copy of the GNU General Public License along
+# with this program in a file in the toplevel directory called "GPLv3".
+# If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #  Loic Dachary <loic@dachary.org>
 #
 # 
 EXTRA_DIST = \
+	GPLv3 \
+	GPLv3-assent.txt \
 	config/ccache.m4 \
 	config/gcov.m4 \
 	examples/Makefile.dos \
@@ -32,12 +36,23 @@ EXTRA_DIST = \
 	java/Makefile.dos \
 	lib/Makefile.dos \
 	tests/Makefile.dos \
-	$(wildcard *.vcproj) \
+	mktab_astud.vcproj \
+	mktab_basic.vcproj \
+	mktab_evx.vcproj \
+	mktab_joker.vcproj \
+	mktab_lowball.vcproj \
+	mktab_packed.vcproj \
+	poker-eval.vcproj \
 	poker-eval.sln \
 	WHATS-HERE.Java \
 	WHATS-HERE \
-	$(wildcard gentoo/dev-games/poker-eval/*.ebuild) \
-	$(wildcard csharp/*.cs) \
+	gentoo/dev-games/poker-eval/poker-eval-133.0-r1.ebuild \
+	csharp/API.cs \
+	csharp/Enum.cs \
+	csharp/EnumResult.cs \
+	csharp/GameParams.cs \
+	csharp/StdDeck.cs \
+	csharp/Test.cs \
 	csharp/Makefile \
 	csharp/TODO \
 	packaging-farm.bat \

--- a/Poker.PokerEval/NEWS
+++ b/Poker.PokerEval/NEWS
@@ -1,3 +1,15 @@
+Release 138.0
+
+Bug fixes.
+
+Release 137.0
+
+Bug fixes.
+
+Release 136.0
+
+Bug fixes.
+
 Release 135.0
 
 Bug fixes.

--- a/Poker.PokerEval/WHATS-HERE.Java
+++ b/Poker.PokerEval/WHATS-HERE.Java
@@ -1,5 +1,5 @@
-BECAUSE OF LICENSING PROBLEMS (IBM LCP and Apache are not compatible with the
-GNU GPL), the Java part is not included in the distribution. 
+BECAUSE OF LICENSING PROBLEMS (IBM CPL is not compatible with the GNU
+GPLv3), the Java part is not included in the distribution.
 
 The PokerSource library includes an optional Java layer.  You can compile the
 C library on its own, or you can compile both the C library and the Java

--- a/Poker.PokerEval/configure.ac
+++ b/Poker.PokerEval/configure.ac
@@ -1,33 +1,32 @@
 #
-# Copyright (C) 2004-2006 Mekensleep
+# Copyright (C) 2004-2010 Loic Dachary <loic@dachary.org>
+# Copyright (C) 2008      Bradley M. Kuhn <bkuhn@ebb.org>
+# Copyright (C) 2004-2006 Mekensleep <licensing@mekensleep.com>
+#                         24 rue vieille du temple, 75004 Paris
 #
-# Mekensleep
-# 24 rue vieille du temple
-# 75004 Paris
-#       licensing@mekensleep.com
+# This program gives you software freedom; you can copy, convey,
+# propagate, redistribute and/or modify this program under the terms of
+# the GNU General Public License (GPL) as published by the Free Software
+# Foundation (FSF), either version 3 of the License, or (at your option)
+# any later version of the GPL published by the FSF.
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# You should have received a copy of the GNU General Public License along
+# with this program in a file in the toplevel directory called "GPLv3".
+# If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #  Loic Dachary <loic@dachary.org>
-# 
+#  Bradley M. Kuhn <bkuhn@ebb.org>
 
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.53)
-AC_INIT(poker-eval, 134.0)
+AC_INIT(poker-eval, 138.0)
 AC_CONFIG_AUX_DIR(config)
 AC_CANONICAL_SYSTEM
 AM_INIT_AUTOMAKE()
@@ -37,11 +36,16 @@ AC_CONFIG_SRCDIR([lib/deck.c])
 # Checks for programs.
 AC_PROG_MAKE_SET
 AC_GNU_SOURCE
-AC_PROG_CPP
 AC_PROG_CC
 AC_PROG_LIBTOOL
 AC_PATH_PROG([AWK], [awk])
+
+# Mac OS X uses md5 instead of md5sum
 AC_PATH_PROG([MD5SUM], [md5sum])
+if test x"$MD5SUM" = x ; then
+  AC_PATH_PROG([MD5SUM], [md5])
+fi
+
 AC_PATH_PROG([VALGRIND], [valgrind])
 
 if test "$GCC" = "yes" ; then
@@ -57,6 +61,7 @@ AC_C_INLINE
 AC_C_CONST
 AC_C_INLINE
 AC_C_BIGENDIAN
+AM_PROG_CC_C_O
 AC_CHECK_SIZEOF(long)
 AC_CHECK_HEADERS(unistd.h)
 AC_CHECK_HEADERS(sys/stat.h)

--- a/Poker.PokerEval/examples/CMakeLists.txt
+++ b/Poker.PokerEval/examples/CMakeLists.txt
@@ -1,0 +1,30 @@
+
+add_executable(five_card_hands
+	${CMAKE_CURRENT_SOURCE_DIR}/examples/five_card_hands.c)
+target_include_directories(five_card_hands PRIVATE include)
+target_link_libraries(five_card_hands PRIVATE PokerEval)
+
+add_executable(hcmp2
+	${CMAKE_CURRENT_SOURCE_DIR}/examples/hcmp2.c)
+target_include_directories(hcmp2 PRIVATE include)
+target_link_libraries(hcmp2 PRIVATE PokerEval)
+
+add_executable(hcmpn
+	${CMAKE_CURRENT_SOURCE_DIR}/examples/hcmpn.c)
+target_include_directories(hcmpn PRIVATE include)
+target_link_libraries(hcmpn PRIVATE PokerEval)
+
+add_executable(pokenum
+	${CMAKE_CURRENT_SOURCE_DIR}/examples/pokenum.c)
+target_include_directories(pokenum PRIVATE include)
+target_link_libraries(pokenum PRIVATE PokerEval)
+
+add_executable(seven_card_hands
+	${CMAKE_CURRENT_SOURCE_DIR}/examples/seven_card_hands.c)
+target_include_directories(seven_card_hands PRIVATE include)
+target_link_libraries(seven_card_hands PRIVATE PokerEval)
+
+add_executable(usedecks
+	${CMAKE_CURRENT_SOURCE_DIR}/examples/usedecks.c)
+target_include_directories(usedecks PRIVATE include)
+target_link_libraries(usedecks PRIVATE PokerEval)

--- a/Poker.PokerEval/examples/Makefile.am
+++ b/Poker.PokerEval/examples/Makefile.am
@@ -1,4 +1,5 @@
 #
+# Copyright (C) 2004-2010 Loic Dachary <loic@dachary.org>
 # Copyright (C) 2004-2006 Mekensleep
 #
 # Mekensleep
@@ -6,19 +7,20 @@
 # 75004 Paris
 #       licensing@mekensleep.com
 #
-#  This package is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; version 2 dated June, 1991.
+# This program gives you software freedom; you can copy, convey,
+# propagate, redistribute and/or modify this program under the terms of
+# the GNU General Public License (GPL) as published by the Free Software
+# Foundation (FSF), either version 3 of the License, or (at your option)
+# any later version of the GPL published by the FSF.
 #
-#  This package is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
 #
-#  You should have received a copy of the GNU General Public License
-#  along with this package; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
-#  MA 02110-1301, USA.
+# You should have received a copy of the GNU General Public License along
+# with this program in a file in the toplevel directory called "GPLv3".
+# If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #  Loic Dachary <loic@dachary.org>
@@ -28,7 +30,18 @@ MAINTAINERCLEANFILES = Makefile.in
 
 INCLUDES = -I$(top_srcdir)/include
 
-EXTRA_DIST = utest1 getopt_w32.c getopt_w32.h $(wildcard *.vcproj) 
+EXTRA_DIST = \
+	utest1 \
+	getopt_w32.c \
+	getopt_w32.h \
+	eval.vcproj \
+	fish.vcproj \
+	five_card_hands.vcproj \
+	hcmp2.vcproj \
+	hcmpn2.vcproj \
+	pokenum.vcproj \
+	seven_card_hands.vcproj \
+	usedecks.vcproj
 
 #TESTS = utest1
 

--- a/Poker.PokerEval/examples/eval.c
+++ b/Poker.PokerEval/examples/eval.c
@@ -6,19 +6,20 @@
  * All it does is evaluate the hand given on the command line
  * and print out the value. 
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <stdio.h>

--- a/Poker.PokerEval/examples/fish.c
+++ b/Poker.PokerEval/examples/fish.c
@@ -12,19 +12,20 @@
  * exhaustively enumerating the set of possible hands which include the input
  * cards and exclude the dead cards.  
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <stdio.h>

--- a/Poker.PokerEval/examples/five_card_hands.c
+++ b/Poker.PokerEval/examples/five_card_hands.c
@@ -3,19 +3,20 @@
  *
  *  Copyright (C) 1993-99 Clifford T. Matthews, Brian Goetz
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/Poker.PokerEval/examples/getopt_w32.c
+++ b/Poker.PokerEval/examples/getopt_w32.c
@@ -1,5 +1,5 @@
 #include "getopt_w32.h"
-
+/* LICENSE: see LICENSE.getopt at the top-level directory. */
 /*
 *  g e t o p t . c
 * 

--- a/Poker.PokerEval/examples/getopt_w32.h
+++ b/Poker.PokerEval/examples/getopt_w32.h
@@ -1,6 +1,8 @@
 #ifndef __GETOPT_W32_H__
 #define __GETOPT_W32_H__
 
+/* LICENSE: see LICENSE.getopt at the top-level directory. */
+
 extern int optind;
 extern char *optarg;
 extern int opterr;

--- a/Poker.PokerEval/examples/hcmp2.c
+++ b/Poker.PokerEval/examples/hcmp2.c
@@ -6,19 +6,20 @@
  *
  *      hcmp2  tc ac  3h ah  8c 6h 7h
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <stdio.h>

--- a/Poker.PokerEval/examples/hcmpn.c
+++ b/Poker.PokerEval/examples/hcmpn.c
@@ -6,19 +6,20 @@
  *
  *      hcmpn  tc ac  3h ah  2h 2d -- 8c 6h 7h
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <stdio.h>

--- a/Poker.PokerEval/examples/pokenum.c
+++ b/Poker.PokerEval/examples/pokenum.c
@@ -4,21 +4,22 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
-/* $Id: pokenum.c 1773 2006-10-12 11:34:41Z loic $
+/* $Id: pokenum.c 5146 2008-12-04 03:11:22Z bkuhn $
    Example showing how to calculate pot equity using the enumeration functions.
    See also hcmp2.c and hcmpn.c for slightly lower level examples.
 

--- a/Poker.PokerEval/examples/seven_card_hands.c
+++ b/Poker.PokerEval/examples/seven_card_hands.c
@@ -3,19 +3,20 @@
  *
  *  Copyright (C) 1993-99 Clifford T. Matthews, Brian Goetz
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/Poker.PokerEval/examples/usedecks.c
+++ b/Poker.PokerEval/examples/usedecks.c
@@ -1,21 +1,22 @@
-/* $Id: usedecks.c 1024 2006-04-22 20:49:41Z loic $
+/* $Id: usedecks.c 5146 2008-12-04 03:11:22Z bkuhn $
    Example showing how to use different decks and evaluation rule sets.
 
-   Michael Maurer, Apr 2002
-
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * Copyright (C) Apr 2002, Michael Maurer.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <stdio.h>

--- a/Poker.PokerEval/examples/utest1
+++ b/Poker.PokerEval/examples/utest1
@@ -4,21 +4,22 @@
 #           Michael Maurer <mjmaurer@yahoo.com>
 #           Loic Dachary <loic@dachary.org>
 #
-#  This package is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; version 2 dated June, 1991.
+# This program gives you software freedom; you can copy, convey,
+# propagate, redistribute and/or modify this program under the terms of
+# the GNU General Public License (GPL) as published by the Free Software
+# Foundation (FSF), either version 3 of the License, or (at your option)
+# any later version of the GPL published by the FSF.
 #
-#  This package is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
 #
-#  You should have received a copy of the GNU General Public License
-#  along with this package; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
-#  MA 02110-1301, USA.
+# You should have received a copy of the GNU General Public License along
+# with this program in a file in the toplevel directory called "GPLv3".
+# If not, see <http://www.gnu.org/licenses/>.
 #
-# $Id: utest1 1773 2006-10-12 11:34:41Z loic $
+# $Id: utest1 5146 2008-12-04 03:11:22Z bkuhn $
 # utest1 -- unit tests for examples
 
 #./pokenum -h Ac 7c - 5s 4s - Ks Kd

--- a/Poker.PokerEval/include/Makefile.am
+++ b/Poker.PokerEval/include/Makefile.am
@@ -1,24 +1,23 @@
 #
 # Copyright (C) 2004-2006 Mekensleep
 #
-# Mekensleep
-# 24 rue vieille du temple
-# 75004 Paris
-#       licensing@mekensleep.com
+# Mekensleep <licensing@mekensleep.com>
+# 24 rue vieille du temple, 75004 Paris
 #
-#  This package is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; version 2 dated June, 1991.
+# This program gives you software freedom; you can copy, convey,
+# propagate, redistribute and/or modify this program under the terms of
+# the GNU General Public License (GPL) as published by the Free Software
+# Foundation (FSF), either version 3 of the License, or (at your option)
+# any later version of the GPL published by the FSF.
 #
-#  This package is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
 #
-#  You should have received a copy of the GNU General Public License
-#  along with this package; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
-#  MA 02110-1301, USA.
+# You should have received a copy of the GNU General Public License along
+# with this program in a file in the toplevel directory called "GPLv3".
+# If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #  Loic Dachary <loic@dachary.org>

--- a/Poker.PokerEval/include/combinations.h
+++ b/Poker.PokerEval/include/combinations.h
@@ -3,19 +3,20 @@
  *           Michael Maurer <mjmaurer@yahoo.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 /* Public declarations for combinations.c */

--- a/Poker.PokerEval/include/config.h.in
+++ b/Poker.PokerEval/include/config.h.in
@@ -1,5 +1,8 @@
 /* include/config.h.in.  Generated from configure.ac by autoheader.  */
 
+/* Define if building universal (internal helper macro) */
+#undef AC_APPLE_UNIVERSAL_BUILD
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #undef HAVE_DLFCN_H
 
@@ -39,6 +42,13 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
+/* Define to the sub-directory in which libtool stores uninstalled libraries.
+   */
+#undef LT_OBJDIR
+
+/* Define to 1 if your C compiler doesn't accept -c and -o together. */
+#undef NO_MINUS_C_MINUS_O
+
 /* Name of package */
 #undef PACKAGE
 
@@ -54,6 +64,9 @@
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
 
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 
@@ -63,17 +76,52 @@
 /* Define to 1 if you have the ANSI C header files. */
 #undef STDC_HEADERS
 
-/* Version number of package */
-#undef VERSION
-
-/* Define to 1 if your processor stores words with the most significant byte
-   first (like Motorola and SPARC, unlike Intel and VAX). */
-#undef WORDS_BIGENDIAN
-
+/* Enable extensions on AIX 3, Interix.  */
+#ifndef _ALL_SOURCE
+# undef _ALL_SOURCE
+#endif
 /* Enable GNU extensions on systems that have them.  */
 #ifndef _GNU_SOURCE
 # undef _GNU_SOURCE
 #endif
+/* Enable threading extensions on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# undef _POSIX_PTHREAD_SEMANTICS
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# undef _TANDEM_SOURCE
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# undef __EXTENSIONS__
+#endif
+
+
+/* Version number of package */
+#undef VERSION
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+#  undef WORDS_BIGENDIAN
+# endif
+#endif
+
+/* Define to 1 if on MINIX. */
+#undef _MINIX
+
+/* Define to 2 if the system does not provide POSIX.1 features except with
+   this defined. */
+#undef _POSIX_1_SOURCE
+
+/* Define to 1 if you need to in order for `stat' and other things to work. */
+#undef _POSIX_SOURCE
 
 /* Define to empty if `const' does not conform to ANSI C. */
 #undef const

--- a/Poker.PokerEval/include/deck.h
+++ b/Poker.PokerEval/include/deck.h
@@ -4,19 +4,20 @@
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef __DECK_H__
 #define __DECK_H__
@@ -39,8 +40,8 @@ typedef struct {
 
 #define Deck_cardToString       (CurDeck.cardToString)
 #define Deck_stringToCard       (CurDeck.stringToCard)
-#define Deck_cardString(i)      GenericDeck_cardString(CurDeck, (i))
-#define Deck_printCard(i)       GenericDeck_printCard(CurDeck, (i))
+#define Deck_cardString(i)      GenericDeck_cardString(&(CurDeck), (i))
+#define Deck_printCard(i)       GenericDeck_printCard(&(CurDeck), (i))
 
 #define Deck_printMask(m)       \
         GenericDeck_printMask(&CurDeck, ((void *) &(m)))

--- a/Poker.PokerEval/include/deck_astud.h
+++ b/Poker.PokerEval/include/deck_astud.h
@@ -4,19 +4,20 @@
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 /*
    Note that this file has two #if .. #endif sections -- one for 
@@ -29,6 +30,7 @@
 
 #include "pokereval_export.h"
 
+/* MUST be lower than STRING_CARDS from lib/deck.c */
 #define AStudDeck_N_CARDS      32
 #define AStudDeck_MASK(index)  (AStudDeck_cardMasksTable[index])
 

--- a/Poker.PokerEval/include/deck_joker.h
+++ b/Poker.PokerEval/include/deck_joker.h
@@ -4,25 +4,27 @@
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef __DECK_JOKER_H__
 #define __DECK_JOKER_H__
 
 #include "pokereval_export.h"
 
+/* MUST be lower than STRING_CARDS from lib/deck.c */
 #define JokerDeck_N_CARDS      53
 #define JokerDeck_MASK(index)  (JokerDeck_cardMasksTable[index])
 

--- a/Poker.PokerEval/include/deck_std.h
+++ b/Poker.PokerEval/include/deck_std.h
@@ -4,19 +4,20 @@
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 /*
    Note that this file has two #if .. #endif sections -- one for 
@@ -29,6 +30,7 @@
 
 #include "pokereval_export.h"
 
+/* MUST be lower than STRING_CARDS from lib/deck.c */
 #define StdDeck_N_CARDS      52
 #define StdDeck_MASK(index)  (StdDeck_cardMasksTable[index])
 

--- a/Poker.PokerEval/include/deck_undef.h
+++ b/Poker.PokerEval/include/deck_undef.h
@@ -1,21 +1,22 @@
 /*
- * Copyright (C) 2004-2006
+ * Copyright (C) 2004-2010
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #undef Deck_N_CARDS      
 #undef Deck_MASK         
@@ -51,6 +52,10 @@
 #undef CardMask_CARD_IS_SET   
 #undef CardMask_ANY_SET       
 #undef CardMask_RESET         
+#undef CardMask_NOT
+#undef CardMask_XOR
+#undef CardMask_AND
+#undef CardMask_UNSET
 
 #undef CardMask_SPADES        
 #undef CardMask_HEARTS        

--- a/Poker.PokerEval/include/enumdefs.h
+++ b/Poker.PokerEval/include/enumdefs.h
@@ -3,21 +3,22 @@
  *           Michael Maurer <mjmaurer@yahoo.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
-/* $Id: enumdefs.h 1773 2006-10-12 11:34:41Z loic $ */
+/* $Id: enumdefs.h 5146 2008-12-04 03:11:22Z bkuhn $ */
 
 #ifndef ENUMDEFS_H
 #define ENUMDEFS_H

--- a/Poker.PokerEval/include/enumerate.h
+++ b/Poker.PokerEval/include/enumerate.h
@@ -4,19 +4,20 @@
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 /*
 Macros to enumerate combinations and permutations of the remaining
@@ -620,7 +621,7 @@ do { \
   _combos = (Combinations *) malloc(num_sets * sizeof(Combinations)); \
   _ncombo = (int *) malloc(num_sets * sizeof(int)); \
   _curIndex = (int *) malloc(num_sets * sizeof(int)); \
-  _curElem = (int **) malloc(num_sets * sizeof(int)); \
+  _curElem = (int **) malloc(num_sets * sizeof(intptr_t)); \
   _curHand = (deck##_CardMask *) malloc(num_sets * sizeof(deck##_CardMask)); \
   for (_i=0; _i<num_sets; _i++) { \
     _combos[_i] = init_combinations(deck##_N_CARDS, set_sizes[_i]); \
@@ -641,7 +642,7 @@ do { \
         if (!deck##_CardMask_ANY_SET(_unavail, set_var[_i])) \
           break;	/* this hand is available for player i */ \
       } \
-      if (_j == _ncombo[_i]) { printf("not enough cards\n"); exit(1); } \
+      if (_j == _ncombo[_i]) { printf("not enough cards\n"); return(1); } \
       deck##_CardMask_OR(_unavail, _unavail, set_var[_i]); \
       _curIndex[_i] = _j; \
     } \

--- a/Poker.PokerEval/include/enumord.h
+++ b/Poker.PokerEval/include/enumord.h
@@ -3,21 +3,22 @@
  *           Michael Maurer <mjmaurer@yahoo.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
-/* $Id: enumord.h 1773 2006-10-12 11:34:41Z loic $ */
+/* $Id: enumord.h 5146 2008-12-04 03:11:22Z bkuhn $ */
 /*
   Definitions for computing a histogram of final hand orderings.
 

--- a/Poker.PokerEval/include/evx_defs.h
+++ b/Poker.PokerEval/include/evx_defs.h
@@ -3,19 +3,20 @@
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef __EVX_DEFS__
 #define __EVX_DEFS__

--- a/Poker.PokerEval/include/game_astud.h
+++ b/Poker.PokerEval/include/game_astud.h
@@ -3,19 +3,20 @@
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef GAME_ASTUD_H
 #define GAME_ASTUD_H

--- a/Poker.PokerEval/include/game_joker.h
+++ b/Poker.PokerEval/include/game_joker.h
@@ -3,19 +3,20 @@
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef GAME_JOKER_H
 #define GAME_JOKER_H

--- a/Poker.PokerEval/include/game_std.h
+++ b/Poker.PokerEval/include/game_std.h
@@ -3,19 +3,20 @@
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef GAME_STD_H
 #define GAME_STD_H

--- a/Poker.PokerEval/include/handval.h
+++ b/Poker.PokerEval/include/handval.h
@@ -3,19 +3,20 @@
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef __HANDVAL_H__
 #define __HANDVAL_H__

--- a/Poker.PokerEval/include/handval_low.h
+++ b/Poker.PokerEval/include/handval_low.h
@@ -3,19 +3,20 @@
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef __HANDVAL_LOW_H__
 #define __HANDVAL_LOW_H__

--- a/Poker.PokerEval/include/inlines/eval.h
+++ b/Poker.PokerEval/include/inlines/eval.h
@@ -3,19 +3,20 @@
  *
  *  Copyright (C) 1993-99 Brian Goetz, Keith Miyake, Clifford T. Matthews
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef __EVAL_H__

--- a/Poker.PokerEval/include/inlines/eval_astud.h
+++ b/Poker.PokerEval/include/inlines/eval_astud.h
@@ -3,19 +3,20 @@
  *
  *  Copyright (C) 1999 Brian Goetz
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef __EVAL_ASTUD_H__

--- a/Poker.PokerEval/include/inlines/eval_joker.h
+++ b/Poker.PokerEval/include/inlines/eval_joker.h
@@ -1,19 +1,20 @@
 /*
  * Copyright (C) 2002 Michael Maurer <mjmaurer@yahoo.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef __EVAL_JOKER_H__
 #define __EVAL_JOKER_H__

--- a/Poker.PokerEval/include/inlines/eval_joker_low.h
+++ b/Poker.PokerEval/include/inlines/eval_joker_low.h
@@ -3,19 +3,20 @@
  *           Michael Maurer <mjmaurer@yahoo.com>
  *           Brian Goetz <brian@quiotix.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef __EVAL_JOKER_LOW_H__
 #define __EVAL_JOKER_LOW_H__

--- a/Poker.PokerEval/include/inlines/eval_joker_low8.h
+++ b/Poker.PokerEval/include/inlines/eval_joker_low8.h
@@ -1,19 +1,20 @@
 /*
  * Copyright (C) 2002 Michael Maurer <mjmaurer@yahoo.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef __EVAL_JOKER_LOW8_H__
 #define __EVAL_JOKER_LOW8_H__

--- a/Poker.PokerEval/include/inlines/eval_low.h
+++ b/Poker.PokerEval/include/inlines/eval_low.h
@@ -3,19 +3,20 @@
  *           Michael Maurer <mjmaurer@yahoo.com>
  *           Brian Goetz <brian@quiotix.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 /* TODO -- review and fix code for hands with >5 cards, in particular
  hands like KK77442, KKK7733, 777KK33, 333KK77, 4444KKK. */

--- a/Poker.PokerEval/include/inlines/eval_low27.h
+++ b/Poker.PokerEval/include/inlines/eval_low27.h
@@ -2,19 +2,20 @@
  *  Copyright (C) 2005 Loic Dachary <loic@dachary.org>
  *                1993-99 Brian Goetz, Keith Miyake, Clifford T. Matthews
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef __EVAL_LOW27_H__

--- a/Poker.PokerEval/include/inlines/eval_low8.h
+++ b/Poker.PokerEval/include/inlines/eval_low8.h
@@ -1,19 +1,20 @@
 /*
  * Copyright (C) 2002 Michael Maurer <mjmaurer@yahoo.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef __EVAL_LOW8_H__
 #define __EVAL_LOW8_H__

--- a/Poker.PokerEval/include/inlines/eval_omaha.h
+++ b/Poker.PokerEval/include/inlines/eval_omaha.h
@@ -1,19 +1,20 @@
 /*
  * Copyright (C) 2002 Michael Maurer <mjmaurer@yahoo.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 /* eval_omaha.h -- Omaha High and Omaha High/Low 8-or-better hand evaluators
  *

--- a/Poker.PokerEval/include/inlines/eval_type.h
+++ b/Poker.PokerEval/include/inlines/eval_type.h
@@ -7,19 +7,20 @@
  *           Michael Maurer <mjmaurer@yahoo.com>
  *           Brian Goetz <brian@quiotix.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef __EVAL_TYPE_H__

--- a/Poker.PokerEval/include/inlines/evx5.h
+++ b/Poker.PokerEval/include/inlines/evx5.h
@@ -5,19 +5,20 @@
  *
  *  Copyright (C) 1994  Clifford T. Matthews
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <stdlib.h>

--- a/Poker.PokerEval/include/inlines/evx7.h
+++ b/Poker.PokerEval/include/inlines/evx7.h
@@ -5,19 +5,20 @@
  *
  *  Copyright (C) 1994  Clifford T. Matthews
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <stdlib.h>

--- a/Poker.PokerEval/include/inlines/evx_action.h
+++ b/Poker.PokerEval/include/inlines/evx_action.h
@@ -5,19 +5,20 @@
  *
  *  Copyright (C) 1994  Clifford T. Matthews
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 /*

--- a/Poker.PokerEval/include/inlines/evx_inlines.h
+++ b/Poker.PokerEval/include/inlines/evx_inlines.h
@@ -6,19 +6,20 @@
  *
  *  Copyright (C) 1994  Clifford T. Matthews
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 static inline uint32 flush_value(StdDeck_RankMask ranks)

--- a/Poker.PokerEval/include/poker_config.h
+++ b/Poker.PokerEval/include/poker_config.h
@@ -4,19 +4,20 @@
  *           Michael Maurer <mjmaurer@yahoo.com>
  *           Loic Dachary <loic@dachary.org>
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef WORDS_BIGENDIAN

--- a/Poker.PokerEval/include/poker_config.h.in
+++ b/Poker.PokerEval/include/poker_config.h.in
@@ -3,19 +3,20 @@
  *           Michael Maurer <mjmaurer@yahoo.com>
  *           Loic Dachary <loic@dachary.org>
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef WORDS_BIGENDIAN

--- a/Poker.PokerEval/include/poker_defs.h
+++ b/Poker.PokerEval/include/poker_defs.h
@@ -4,19 +4,20 @@
  *           Loic Dachary <loic@dachary.org>
  *           Igor Kravtchenko <igor@obraz.net>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef __POKER_DEFS_H__
 #define __POKER_DEFS_H__

--- a/Poker.PokerEval/include/poker_wrapper.h
+++ b/Poker.PokerEval/include/poker_wrapper.h
@@ -1,19 +1,20 @@
 /*
  *  Copyright 2006 Loic Dachary <loic@dachary.org> 
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef __POKER_WRAPPER_H__
@@ -25,32 +26,32 @@
 
 extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_N_CARDS(void);
 extern POKEREVAL_EXPORT StdDeck_CardMask wrap_StdDeck_MASK(int index);
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_2();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_3();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_4();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_5();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_6();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_7();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_8();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_9();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_TEN();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_JACK();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_QUEEN();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_KING();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_ACE();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_COUNT();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_FIRST();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_LAST();
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_2(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_3(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_4(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_5(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_6(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_7(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_8(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_9(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_TEN(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_JACK(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_QUEEN(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_KING(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_ACE(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_COUNT(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_FIRST(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Rank_LAST(void);
 extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_RANK(unsigned int index);
 extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_SUIT(unsigned int index);
 extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_MAKE_CARD(unsigned int rank, unsigned int suit);
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Suit_HEARTS();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Suit_DIAMONDS();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Suit_CLUBS();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Suit_SPADES();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Suit_FIRST();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Suit_LAST();
-extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Suit_COUNT();
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Suit_HEARTS(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Suit_DIAMONDS(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Suit_CLUBS(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Suit_SPADES(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Suit_FIRST(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Suit_LAST(void);
+extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_Suit_COUNT(void);
 extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_CardMask_SPADES(StdDeck_CardMask cm);
 extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_CardMask_CLUBS(StdDeck_CardMask cm);
 extern POKEREVAL_EXPORT unsigned int wrap_StdDeck_CardMask_DIAMONDS(StdDeck_CardMask cm);
@@ -67,7 +68,7 @@ extern POKEREVAL_EXPORT StdDeck_CardMask wrap_StdDeck_CardMask_SET(StdDeck_CardM
 extern POKEREVAL_EXPORT StdDeck_CardMask wrap_StdDeck_CardMask_UNSET(StdDeck_CardMask mask, unsigned int index);
 extern POKEREVAL_EXPORT int wrap_StdDeck_CardMask_CARD_IS_SET(StdDeck_CardMask mask, unsigned int index);
 extern POKEREVAL_EXPORT int wrap_StdDeck_CardMask_ANY_SET(StdDeck_CardMask mask1, StdDeck_CardMask mask2);
-extern POKEREVAL_EXPORT StdDeck_CardMask wrap_StdDeck_CardMask_RESET();
+extern POKEREVAL_EXPORT StdDeck_CardMask wrap_StdDeck_CardMask_RESET(void);
 extern POKEREVAL_EXPORT int wrap_StdDeck_CardMask_IS_EMPTY(StdDeck_CardMask mask);
 extern POKEREVAL_EXPORT int wrap_StdDeck_CardMask_EQUAL(StdDeck_CardMask mask1, StdDeck_CardMask mask2);
 

--- a/Poker.PokerEval/include/pokereval_export.h
+++ b/Poker.PokerEval/include/pokereval_export.h
@@ -1,24 +1,23 @@
 /*
  * Copyright (C) 2004-2006 Mekensleep
  *
- * Mekensleep
- * 24 rue vieille du temple
- * 75004 Paris
- *       licensing@mekensleep.com
+ * Mekensleep <licensing@mekensleep.com>
+ * 24 rue vieille du temple, 75004 Paris
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  *
  * Authors:
  *  Loic Dachary <loic@dachary.org>

--- a/Poker.PokerEval/include/rules_astud.h
+++ b/Poker.PokerEval/include/rules_astud.h
@@ -3,19 +3,20 @@
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 /*
    Note that this file has two #if .. #endif sections -- one for 

--- a/Poker.PokerEval/include/rules_joker.h
+++ b/Poker.PokerEval/include/rules_joker.h
@@ -3,19 +3,20 @@
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 /*
    Note that this file has two #if .. #endif sections -- one for 

--- a/Poker.PokerEval/include/rules_std.h
+++ b/Poker.PokerEval/include/rules_std.h
@@ -3,19 +3,20 @@
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 /*
    Note that this file has two #if .. #endif sections -- one for 

--- a/Poker.PokerEval/include/rules_undef.h
+++ b/Poker.PokerEval/include/rules_undef.h
@@ -3,19 +3,20 @@
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #undef HandType_NOPAIR    
 #undef HandType_ONEPAIR   

--- a/Poker.PokerEval/lib/CMakeLists.txt
+++ b/Poker.PokerEval/lib/CMakeLists.txt
@@ -1,0 +1,99 @@
+
+add_library(PokerEval STATIC
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/combinations.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/deck.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/deck_astud.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/deck_joker.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/deck_std.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/enumerate.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/enumord.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/evx.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/lowball.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/rules_astud.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/rules_joker.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/rules_std.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_astudcardmasks.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_botcard.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_botfivecards.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_botfivecardsj.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_cardmasks.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_evx_flushcards.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_evx_pairval.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_evx_strval.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_evx_tripsval.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_jokercardmasks.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_jokerstraight.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_maskrank.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_nbits.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_nbitsandstr.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_straight.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_topbit.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_topcard.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_topfivebits.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_topfivecards.c
+	${CMAKE_CURRENT_SOURCE_DIR}/lib/t_toptwobits.c)
+target_include_directories(PokerEval PRIVATE include)
+set_target_properties(PokerEval PROPERTIES LINKER_LANGUAGE C)
+set_target_properties(PokerEval PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+add_executable(mktab_basic
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktable.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktable_utils.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktab_basic.c)
+target_include_directories(mktab_basic PRIVATE include)
+set_target_properties(mktab_basic PROPERTIES LINKER_LANGUAGE C)
+target_link_libraries(mktab_basic PRIVATE PokerEval)
+
+add_executable(mktab_joker
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktable.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktable_utils.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktab_joker.c)
+target_include_directories(mktab_joker PRIVATE include)
+set_target_properties(mktab_joker PROPERTIES LINKER_LANGUAGE C)
+target_link_libraries(mktab_joker PRIVATE PokerEval)
+
+add_executable(mktab_packed
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktable.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktable_utils.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktab_packed.c)
+target_include_directories(mktab_packed PRIVATE include)
+set_target_properties(mktab_packed PROPERTIES LINKER_LANGUAGE C)
+target_link_libraries(mktab_packed PRIVATE PokerEval)
+
+add_executable(mktab_evx
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktable.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktable_utils.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktab_evx.c)
+target_include_directories(mktab_evx PRIVATE include)
+set_target_properties(mktab_evx PROPERTIES LINKER_LANGUAGE C)
+target_link_libraries(mktab_evx PRIVATE PokerEval)
+
+add_executable(mktab_astud
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktable.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktable_utils.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktab_astud.c)
+target_include_directories(mktab_astud PRIVATE include)
+set_target_properties(mktab_astud PROPERTIES LINKER_LANGUAGE C)
+target_link_libraries(mktab_astud PRIVATE PokerEval)
+
+add_executable(mktab_lowball
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktable.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktable_utils.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/mktab_lowball.c)
+target_include_directories(mktab_lowball PRIVATE include)
+set_target_properties(mktab_lowball PROPERTIES LINKER_LANGUAGE C)
+target_link_libraries(mktab_lowball PRIVATE PokerEval)
+
+# add_executable(evx_gen5
+#     ${CMAKE_CURRENT_SOURCE_DIR}/lib/evx_generate.c)
+# target_include_directories(evx_gen5 PRIVATE include)
+# set_target_properties(evx_gen5 PROPERTIES LINKER_LANGUAGE C)
+# set_target_properties(evx_gen5 PROPERTIES CMAKE_C_FLAGS "-DCARDS_DEALT=5")
+# target_link_libraries(evx_gen5 PRIVATE PokerEval)
+# 
+# add_executable(evx_gen7
+#     ${CMAKE_CURRENT_SOURCE_DIR}/lib/evx_generate.c)
+# target_include_directories(evx_gen7 PRIVATE include)
+# set_target_properties(evx_gen7 PROPERTIES LINKER_LANGUAGE C)
+# set_target_properties(evx_gen7 PROPERTIES CMAKE_C_FLAGS "-DCARDS_DEALT=7")
+# target_link_libraries(evx_gen7 PRIVATE PokerEval)

--- a/Poker.PokerEval/lib/Makefile.am
+++ b/Poker.PokerEval/lib/Makefile.am
@@ -1,24 +1,24 @@
 #
 # Copyright (C) 2004-2006 Mekensleep
 #
-# Mekensleep
-# 24 rue vieille du temple
-# 75004 Paris
-#       licensing@mekensleep.com
+# Mekensleep <licensing@mekensleep.com>
+# 24 rue vieille du temple, 75004 Paris
+#       
 #
-#  This package is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; version 2 dated June, 1991.
+# This program gives you software freedom; you can copy, convey,
+# propagate, redistribute and/or modify this program under the terms of
+# the GNU General Public License (GPL) as published by the Free Software
+# Foundation (FSF), either version 3 of the License, or (at your option)
+# any later version of the GPL published by the FSF.
 #
-#  This package is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
 #
-#  You should have received a copy of the GNU General Public License
-#  along with this package; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
-#  MA 02110-1301, USA.
+# You should have received a copy of the GNU General Public License along
+# with this program in a file in the toplevel directory called "GPLv3".
+# If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors:
 #  Loic Dachary <loic@dachary.org>
@@ -126,11 +126,11 @@ evx_gen7_SOURCES = evx_generate.c
 evx_gen7_CPPFLAGS = -DCARDS_DEALT=7
 
 all-local: evx_gen5 evx_gen7 evx_preamble.cfrag
-	if [ -w $(top_srcdir)/include/inlines/evx5.h ] ; then \
-		./evx_gen5 > $(top_srcdir)/include/inlines/evx5.h ; \
+	if [ -w "$(top_srcdir)/include/inlines/evx5.h" ] ; then \
+		./evx_gen5 "$(srcdir)" > "$(top_srcdir)/include/inlines/evx5.h" ; \
 	fi
-	if [ -w $(top_srcdir)/include/inlines/evx7.h ] ; then \
-		./evx_gen7 > $(top_srcdir)/include/inlines/evx7.h ; \
+	if [ -w "$(top_srcdir)/include/inlines/evx7.h" ] ; then \
+		./evx_gen7 "$(srcdir)" > "$(top_srcdir)/include/inlines/evx7.h" ; \
 	fi
 
 clean-local:

--- a/Poker.PokerEval/lib/combinations.c
+++ b/Poker.PokerEval/lib/combinations.c
@@ -1,25 +1,26 @@
-/* $Id: combinations.c 1024 2006-04-22 20:49:41Z loic $
+/* $Id: combinations.c 5439 2009-01-02 10:53:19Z loic $
    Combinations (N choose R).
 
    Provides an enumeration of all (N choose R) combinations of R elements from
    a set of N.  The get_combination() function returns a specific combination
    as an integer array with R elements in [0..N-1].
 
-   Michael Maurer, Jun 2002
-
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+   Copyright (C) Jun 2002, Michael Maurer.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include <stdio.h>
@@ -91,7 +92,8 @@ init_combinations(int nuniv, int nelem)
         break;
       }
     }
-    if (firstIncr == -1) { printf("BUG!\n"); exit(1); }
+    if (firstIncr == -1) 
+      return NULL;
     for (i=0; i<firstIncr; i++)
       combo->combos[i][j] = combo->combos[i][j-1];
     for (i=firstIncr+1; i<combo->nelem; i++)

--- a/Poker.PokerEval/lib/deck.c
+++ b/Poker.PokerEval/lib/deck.c
@@ -4,27 +4,34 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 #include "poker_defs.h"
 
+/*
+ * This number MUST be higher than any of the *_N_CARDS constants
+ * listed in the *_deck.h files in the include directory, 52 for
+ * a standard deck for instance. 
+ */
+#define STRING_CARDS 100
 
 int
 GenericDeck_maskToString(Deck *deck, void *cardMask, char *outString) {
-  int cards[50], n, i;
+  int cards[STRING_CARDS], n, i;
   char *p;
 
   n = (*deck->maskToCards)(cardMask, cards);
@@ -42,7 +49,7 @@ GenericDeck_maskToString(Deck *deck, void *cardMask, char *outString) {
 
 int 
 GenericDeck_printMask(Deck *deck, void *cardMask) {
-  char outString[150];
+  char outString[300];
   int r;
 
   r = GenericDeck_maskToString(deck, cardMask, outString);

--- a/Poker.PokerEval/lib/deck_astud.c
+++ b/Poker.PokerEval/lib/deck_astud.c
@@ -4,19 +4,20 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 #include <ctype.h>

--- a/Poker.PokerEval/lib/deck_joker.c
+++ b/Poker.PokerEval/lib/deck_joker.c
@@ -4,19 +4,20 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 #include <ctype.h>

--- a/Poker.PokerEval/lib/deck_std.c
+++ b/Poker.PokerEval/lib/deck_std.c
@@ -4,19 +4,20 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 #include <ctype.h>

--- a/Poker.PokerEval/lib/enumerate.c
+++ b/Poker.PokerEval/lib/enumerate.c
@@ -9,21 +9,22 @@
         enumResultPrintTerse()	print enumeration result object, tersely
         enumSample()		monte carlo sampling of outcomes
 
-   Michael Maurer, Apr 2002
-
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+   Copyright (C) Apr 2002, Michael Maurer.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <stdio.h>

--- a/Poker.PokerEval/lib/enumord.c
+++ b/Poker.PokerEval/lib/enumord.c
@@ -1,21 +1,22 @@
-/* $Id: enumord.c 1024 2006-04-22 20:49:41Z loic $ */
+/* $Id: enumord.c 5146 2008-12-04 03:11:22Z bkuhn $ */
 /*
   See comments in enumord.h.
-  Michael Maurer, Jun 2002
-
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+  Copyright (C) Jun 2002, Michael Maurer.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <stdlib.h>

--- a/Poker.PokerEval/lib/evx.c
+++ b/Poker.PokerEval/lib/evx.c
@@ -4,19 +4,20 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <assert.h>
 

--- a/Poker.PokerEval/lib/evx_generate.c
+++ b/Poker.PokerEval/lib/evx_generate.c
@@ -4,19 +4,20 @@
  *
  *  Copyright (C) 1994-99    Clifford T. Matthews, Brian Goetz
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "poker_defs.h"
@@ -37,6 +38,8 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+
+#include <string.h>
 
 typedef enum {
   MAY_HAVE_FOUR_OF_A_KIND  = (1 << 0),
@@ -60,16 +63,31 @@ static uint8 may_have[MAY_HAVE_COMBINATIONS][StdDeck_N_RANKMASKS / 8];
 static void compute_cases (void);
 static void print_cases (void);
 
+#define PREAMBLE_FRAG "evx_preamble.cfrag"
+
+/*
+ * Pass in path to the pre-amble as first argument so we can separate build
+ * from source directory.
+ */
+
 int
 main (int argc, char** argv)
 {
+  char *frag_path;
   FILE *fp;
 
+  if (argc != 2) {
+      fprintf (stderr, "Usage: %s path/evx_preamble.cfrag\n", argv[0]);
+      return -1;
+  }
+  frag_path = malloc (strlen (argv[1]) + 1 + strlen (PREAMBLE_FRAG) + 1);
+  sprintf(frag_path, "%s/" PREAMBLE_FRAG, argv[1]);
+  
   /* Copy the preamble to stdout. */
-  fp = fopen ("evx_preamble.cfrag", "r");
+  fp = fopen (frag_path, "r");
   if (fp == NULL) {
-      fprintf (stderr, "Unable to read evx_preamble.c\n");
-      exit (-1);
+      fprintf (stderr, "Unable to read %s\n", frag_path);
+      return -1;
     }
   puts("/* This file is machine-generated -- DO NOT EDIT! */\n");
   {
@@ -81,6 +99,7 @@ main (int argc, char** argv)
     (void)fread (p, sbuf.st_size, 1, fp);
     p[sbuf.st_size] = 0;
     printf (p, CARDS_DEALT);
+    free(p);
   }
   fclose (fp);
 

--- a/Poker.PokerEval/lib/evx_preamble.cfrag
+++ b/Poker.PokerEval/lib/evx_preamble.cfrag
@@ -3,19 +3,20 @@
  *
  *  Copyright (C) 1994  Clifford T. Matthews
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <stdlib.h>

--- a/Poker.PokerEval/lib/lowball.c
+++ b/Poker.PokerEval/lib/lowball.c
@@ -4,19 +4,20 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 

--- a/Poker.PokerEval/lib/mktab_astud.c
+++ b/Poker.PokerEval/lib/mktab_astud.c
@@ -4,19 +4,20 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 

--- a/Poker.PokerEval/lib/mktab_basic.c
+++ b/Poker.PokerEval/lib/mktab_basic.c
@@ -4,19 +4,20 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 

--- a/Poker.PokerEval/lib/mktab_evx.c
+++ b/Poker.PokerEval/lib/mktab_evx.c
@@ -4,19 +4,20 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 #include <assert.h>

--- a/Poker.PokerEval/lib/mktab_joker.c
+++ b/Poker.PokerEval/lib/mktab_joker.c
@@ -4,19 +4,20 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 

--- a/Poker.PokerEval/lib/mktab_lowball.c
+++ b/Poker.PokerEval/lib/mktab_lowball.c
@@ -4,19 +4,20 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 

--- a/Poker.PokerEval/lib/mktab_packed.c
+++ b/Poker.PokerEval/lib/mktab_packed.c
@@ -4,19 +4,20 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 #include <assert.h>

--- a/Poker.PokerEval/lib/mktable.c
+++ b/Poker.PokerEval/lib/mktable.c
@@ -4,19 +4,20 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 #include <string.h>

--- a/Poker.PokerEval/lib/mktable.h
+++ b/Poker.PokerEval/lib/mktable.h
@@ -4,19 +4,20 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 extern void
 MakeTable_begin(const char *tableName,

--- a/Poker.PokerEval/lib/mktable_utils.c
+++ b/Poker.PokerEval/lib/mktable_utils.c
@@ -4,19 +4,20 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #include "poker_defs.h"
 #include "mktable.h"

--- a/Poker.PokerEval/lib/poker_wrapper.c
+++ b/Poker.PokerEval/lib/poker_wrapper.c
@@ -1,19 +1,20 @@
 /*
  *  Copyright 2006 Loic Dachary <loic@dachary.org> 
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <poker_defs.h>
@@ -23,32 +24,32 @@ unsigned int wrap_StdDeck_N_CARDS(void) { return StdDeck_N_CARDS; }
 
 StdDeck_CardMask wrap_StdDeck_MASK(int index) { return StdDeck_MASK(index); }
 
-unsigned int wrap_StdDeck_Rank_2() { return StdDeck_Rank_2; }
-unsigned int wrap_StdDeck_Rank_3() { return StdDeck_Rank_3; }
-unsigned int wrap_StdDeck_Rank_4() { return StdDeck_Rank_4; }
-unsigned int wrap_StdDeck_Rank_5() { return StdDeck_Rank_5; }
-unsigned int wrap_StdDeck_Rank_6() { return StdDeck_Rank_6; }
-unsigned int wrap_StdDeck_Rank_7() { return StdDeck_Rank_7; }
-unsigned int wrap_StdDeck_Rank_8() { return StdDeck_Rank_8; }
-unsigned int wrap_StdDeck_Rank_9() { return StdDeck_Rank_9; }
-unsigned int wrap_StdDeck_Rank_TEN() { return StdDeck_Rank_TEN; }
-unsigned int wrap_StdDeck_Rank_JACK() { return StdDeck_Rank_JACK; }
-unsigned int wrap_StdDeck_Rank_QUEEN() { return StdDeck_Rank_QUEEN; }
-unsigned int wrap_StdDeck_Rank_KING() { return StdDeck_Rank_KING; }
-unsigned int wrap_StdDeck_Rank_ACE() { return StdDeck_Rank_ACE; }
-unsigned int wrap_StdDeck_Rank_COUNT() { return StdDeck_Rank_COUNT; }
-unsigned int wrap_StdDeck_Rank_FIRST() { return StdDeck_Rank_FIRST; }
-unsigned int wrap_StdDeck_Rank_LAST() { return StdDeck_Rank_LAST; }
+unsigned int wrap_StdDeck_Rank_2(void) { return StdDeck_Rank_2; }
+unsigned int wrap_StdDeck_Rank_3(void) { return StdDeck_Rank_3; }
+unsigned int wrap_StdDeck_Rank_4(void) { return StdDeck_Rank_4; }
+unsigned int wrap_StdDeck_Rank_5(void) { return StdDeck_Rank_5; }
+unsigned int wrap_StdDeck_Rank_6(void) { return StdDeck_Rank_6; }
+unsigned int wrap_StdDeck_Rank_7(void) { return StdDeck_Rank_7; }
+unsigned int wrap_StdDeck_Rank_8(void) { return StdDeck_Rank_8; }
+unsigned int wrap_StdDeck_Rank_9(void) { return StdDeck_Rank_9; }
+unsigned int wrap_StdDeck_Rank_TEN(void) { return StdDeck_Rank_TEN; }
+unsigned int wrap_StdDeck_Rank_JACK(void) { return StdDeck_Rank_JACK; }
+unsigned int wrap_StdDeck_Rank_QUEEN(void) { return StdDeck_Rank_QUEEN; }
+unsigned int wrap_StdDeck_Rank_KING(void) { return StdDeck_Rank_KING; }
+unsigned int wrap_StdDeck_Rank_ACE(void) { return StdDeck_Rank_ACE; }
+unsigned int wrap_StdDeck_Rank_COUNT(void) { return StdDeck_Rank_COUNT; }
+unsigned int wrap_StdDeck_Rank_FIRST(void) { return StdDeck_Rank_FIRST; }
+unsigned int wrap_StdDeck_Rank_LAST(void) { return StdDeck_Rank_LAST; }
 unsigned int wrap_StdDeck_RANK(unsigned int index) { return StdDeck_RANK(index); }
 unsigned int wrap_StdDeck_SUIT(unsigned int index) { return StdDeck_SUIT(index); }
 unsigned int wrap_StdDeck_MAKE_CARD(unsigned int rank, unsigned int suit) { return StdDeck_MAKE_CARD(rank, suit); }
-unsigned int wrap_StdDeck_Suit_HEARTS() { return StdDeck_Suit_HEARTS; }
-unsigned int wrap_StdDeck_Suit_DIAMONDS() { return StdDeck_Suit_DIAMONDS; }
-unsigned int wrap_StdDeck_Suit_CLUBS() { return StdDeck_Suit_CLUBS; }
-unsigned int wrap_StdDeck_Suit_SPADES() { return StdDeck_Suit_SPADES; }
-unsigned int wrap_StdDeck_Suit_FIRST() { return StdDeck_Suit_FIRST; }
-unsigned int wrap_StdDeck_Suit_LAST() { return StdDeck_Suit_LAST; }
-unsigned int wrap_StdDeck_Suit_COUNT() { return StdDeck_Suit_COUNT; }
+unsigned int wrap_StdDeck_Suit_HEARTS(void) { return StdDeck_Suit_HEARTS; }
+unsigned int wrap_StdDeck_Suit_DIAMONDS(void) { return StdDeck_Suit_DIAMONDS; }
+unsigned int wrap_StdDeck_Suit_CLUBS(void) { return StdDeck_Suit_CLUBS; }
+unsigned int wrap_StdDeck_Suit_SPADES(void) { return StdDeck_Suit_SPADES; }
+unsigned int wrap_StdDeck_Suit_FIRST(void) { return StdDeck_Suit_FIRST; }
+unsigned int wrap_StdDeck_Suit_LAST(void) { return StdDeck_Suit_LAST; }
+unsigned int wrap_StdDeck_Suit_COUNT(void) { return StdDeck_Suit_COUNT; }
 
 unsigned int wrap_StdDeck_CardMask_SPADES(StdDeck_CardMask cm) { return StdDeck_CardMask_SPADES(cm); }
 unsigned int wrap_StdDeck_CardMask_CLUBS(StdDeck_CardMask cm) { return StdDeck_CardMask_CLUBS(cm); }
@@ -66,6 +67,6 @@ StdDeck_CardMask wrap_StdDeck_CardMask_SET(StdDeck_CardMask mask, unsigned int i
 StdDeck_CardMask wrap_StdDeck_CardMask_UNSET(StdDeck_CardMask mask, unsigned int index) { StdDeck_CardMask_UNSET(mask, index); return mask; }
 int wrap_StdDeck_CardMask_CARD_IS_SET(StdDeck_CardMask mask, unsigned int index) { return StdDeck_CardMask_CARD_IS_SET(mask, index); }
 int wrap_StdDeck_CardMask_ANY_SET(StdDeck_CardMask mask1, StdDeck_CardMask mask2) { return StdDeck_CardMask_ANY_SET(mask1, mask2); }
-StdDeck_CardMask wrap_StdDeck_CardMask_RESET() { StdDeck_CardMask mask; StdDeck_CardMask_RESET(mask); return mask; }
+StdDeck_CardMask wrap_StdDeck_CardMask_RESET(void) { StdDeck_CardMask mask; StdDeck_CardMask_RESET(mask); return mask; }
 int wrap_StdDeck_CardMask_IS_EMPTY(StdDeck_CardMask mask) { return StdDeck_CardMask_IS_EMPTY(mask); }
 int wrap_StdDeck_CardMask_EQUAL(StdDeck_CardMask mask1, StdDeck_CardMask mask2) { return StdDeck_CardMask_EQUAL(mask1, mask2); }

--- a/Poker.PokerEval/lib/rules_astud.c
+++ b/Poker.PokerEval/lib/rules_astud.c
@@ -4,19 +4,20 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 

--- a/Poker.PokerEval/lib/rules_joker.c
+++ b/Poker.PokerEval/lib/rules_joker.c
@@ -4,19 +4,20 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 

--- a/Poker.PokerEval/lib/rules_std.c
+++ b/Poker.PokerEval/lib/rules_std.c
@@ -4,19 +4,20 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 

--- a/Poker.PokerEval/make_master.sh
+++ b/Poker.PokerEval/make_master.sh
@@ -1,4 +1,25 @@
 #!/bin/bash
+#
+# Copyright (C) 2006 Mekensleep
+#
+# This program gives you software freedom; you can copy, convey,
+# propagate, redistribute and/or modify this program under the terms of
+# the GNU General Public License (GPL) as published by the Free Software
+# Foundation (FSF), either version 3 of the License, or (at your option)
+# any later version of the GPL published by the FSF.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program in a file in the toplevel directory called "GPLv3".
+# If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#  Johan Euphrosine <proppy@aminche.com>
+#
 
 BUILDDIR=$1
 MASTERDIR=$2

--- a/Poker.PokerEval/mktab_astud.vcproj
+++ b/Poker.PokerEval/mktab_astud.vcproj
@@ -1,277 +1,192 @@
 <?xml version="1.0" encoding="shift_jis"?>
 <VisualStudioProject
 	ProjectType="Visual C++"
-	Version="9.00"
+	Version="7.10"
 	Name="mktab_astud"
 	ProjectGUID="{A3403F9E-5D43-4EE0-97AF-9310762C1863}"
 	RootNamespace="mktab_astud"
-	Keyword="Win32Proj"
-	TargetFrameworkVersion="131072"
-	>
+	Keyword="Win32Proj">
 	<Platforms>
 		<Platform
-			Name="Win32"
-		/>
+			Name="Win32"/>
 	</Platforms>
-	<ToolFiles>
-	</ToolFiles>
 	<Configurations>
 		<Configuration
 			Name="Debug|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-			/>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
+				OptimizeForProcessor="0"
 				AdditionalIncludeDirectories="&quot;.\include&quot;;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_CONSOLE"
-				StringPooling="false"
-				MinimalRebuild="true"
+				StringPooling="FALSE"
+				MinimalRebuild="TRUE"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"
-				BufferSecurityCheck="true"
-				UsePrecompiledHeader="0"
+				BufferSecurityCheck="TRUE"
+				UsePrecompiledHeader="2"
 				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
+				Detect64BitPortabilityProblems="TRUE"
 				DebugInformationFormat="4"
-				CompileAs="2"
-			/>
+				CompileAs="2"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCCustomBuildTool"/>
 			<Tool
 				Name="VCLinkerTool"
-				IgnoreImportLibrary="false"
+				IgnoreImportLibrary="FALSE"
 				OutputFile="$(OutDir)/mktab_astud.exe"
 				LinkIncremental="2"
-				GenerateDebugInformation="true"
+				GenerateDebugInformation="TRUE"
 				ProgramDatabaseFile="$(OutDir)/mktab_astud.pdb"
 				SubSystem="1"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				TargetMachine="1"
-			/>
+				TargetMachine="1"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
-			<Tool
-				Name="VCManifestTool"
-			/>
-			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
+				Name="VCMIDLTool"/>
 			<Tool
 				Name="VCPostBuildEventTool"
 				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
+			<Tool
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
+			<Tool
+				Name="VCResourceCompilerTool"/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"/>
+			<Tool
+				Name="VCWebDeploymentTool"/>
+			<Tool
+				Name="VCManagedWrapperGeneratorTool"/>
+			<Tool
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 		<Configuration
 			Name="Release|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-			/>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="2"
 				InlineFunctionExpansion="1"
-				OmitFramePointers="true"
+				OmitFramePointers="TRUE"
 				AdditionalIncludeDirectories="&quot;.\include&quot;;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE,POKEREVAL_LIBRARY"
-				StringPooling="true"
+				StringPooling="TRUE"
 				RuntimeLibrary="2"
-				EnableFunctionLevelLinking="true"
-				ForceConformanceInForLoopScope="true"
+				EnableFunctionLevelLinking="TRUE"
+				ForceConformanceInForLoopScope="TRUE"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
+				Detect64BitPortabilityProblems="TRUE"
 				DebugInformationFormat="3"
-				CompileAs="2"
-			/>
+				CompileAs="2"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCCustomBuildTool"/>
 			<Tool
 				Name="VCLinkerTool"
 				OutputFile="$(OutDir)/mktab_astud.exe"
 				LinkIncremental="1"
-				GenerateDebugInformation="true"
+				GenerateDebugInformation="TRUE"
 				SubSystem="1"
 				OptimizeReferences="2"
 				EnableCOMDATFolding="2"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				TargetMachine="1"
-			/>
+				TargetMachine="1"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
-			<Tool
-				Name="VCManifestTool"
-			/>
-			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
+				Name="VCMIDLTool"/>
 			<Tool
 				Name="VCPostBuildEventTool"
 				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
+			<Tool
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
+			<Tool
+				Name="VCResourceCompilerTool"/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"/>
+			<Tool
+				Name="VCWebDeploymentTool"/>
+			<Tool
+				Name="VCManagedWrapperGeneratorTool"/>
+			<Tool
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 		<Configuration
 			Name="profile|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-			/>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="2"
 				InlineFunctionExpansion="1"
-				OmitFramePointers="true"
+				OmitFramePointers="TRUE"
 				AdditionalIncludeDirectories="&quot;.\include&quot;;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE,POKEREVAL_LIBRARY"
-				StringPooling="true"
+				StringPooling="TRUE"
 				RuntimeLibrary="2"
-				EnableFunctionLevelLinking="true"
-				ForceConformanceInForLoopScope="true"
+				EnableFunctionLevelLinking="TRUE"
+				ForceConformanceInForLoopScope="TRUE"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
+				Detect64BitPortabilityProblems="TRUE"
 				DebugInformationFormat="3"
-				CompileAs="2"
-			/>
+				CompileAs="2"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCCustomBuildTool"/>
 			<Tool
 				Name="VCLinkerTool"
 				OutputFile="$(OutDir)/mktab_astud.exe"
 				LinkIncremental="1"
-				GenerateDebugInformation="true"
+				GenerateDebugInformation="TRUE"
 				SubSystem="1"
 				OptimizeReferences="2"
 				EnableCOMDATFolding="2"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				TargetMachine="1"
-			/>
+				TargetMachine="1"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
-			<Tool
-				Name="VCManifestTool"
-			/>
-			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
+				Name="VCMIDLTool"/>
 			<Tool
 				Name="VCPostBuildEventTool"
 				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
+			<Tool
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
+			<Tool
+				Name="VCResourceCompilerTool"/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"/>
+			<Tool
+				Name="VCWebDeploymentTool"/>
+			<Tool
+				Name="VCManagedWrapperGeneratorTool"/>
+			<Tool
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 	</Configurations>
 	<References>
@@ -279,43 +194,34 @@
 	<Files>
 		<Filter
 			Name="Source Files"
-			Filter="cpp;c;cxx;def;odl;idl;hpj;bat;asm"
-			>
+			Filter="cpp;c;cxx;def;odl;idl;hpj;bat;asm">
 			<File
-				RelativePath=".\lib\mktab_astud.c"
-				>
+				RelativePath=".\lib\mktab_astud.c">
 			</File>
 			<File
-				RelativePath=".\lib\mktable.c"
-				>
+				RelativePath=".\lib\mktable.c">
 			</File>
 			<File
-				RelativePath=".\lib\mktable_utils.c"
-				>
+				RelativePath=".\lib\mktable_utils.c">
 			</File>
 		</Filter>
 		<Filter
 			Name="Header Files"
-			Filter="h;hpp;hxx;hm;inl;inc"
-			>
+			Filter="h;hpp;hxx;hm;inl;inc">
 			<File
-				RelativePath=".\include\deck_astud.h"
-				>
+				RelativePath=".\include\deck_astud.h">
 			</File>
 			<File
-				RelativePath=".\lib\mktable.h"
-				>
+				RelativePath=".\lib\mktable.h">
 			</File>
 			<File
-				RelativePath=".\include\poker_defs.h"
-				>
+				RelativePath=".\include\poker_defs.h">
 			</File>
 		</Filter>
 	</Files>
 	<Globals>
 		<Global
 			Name="DevPartner_IsInstrumented"
-			Value="0"
-		/>
+			Value="0"/>
 	</Globals>
 </VisualStudioProject>

--- a/Poker.PokerEval/mktab_basic.vcproj
+++ b/Poker.PokerEval/mktab_basic.vcproj
@@ -1,319 +1,234 @@
 <?xml version="1.0" encoding="shift_jis"?>
 <VisualStudioProject
 	ProjectType="Visual C++"
-	Version="9.00"
+	Version="7.10"
 	Name="mktab_basic"
 	ProjectGUID="{FEF5F6D8-D0D3-44D3-B821-2BEF75046F3C}"
 	RootNamespace="mktab_basic"
-	Keyword="AtlProj"
-	TargetFrameworkVersion="131072"
-	>
+	Keyword="AtlProj">
 	<Platforms>
 		<Platform
-			Name="Win32"
-		/>
+			Name="Win32"/>
 	</Platforms>
-	<ToolFiles>
-	</ToolFiles>
 	<Configurations>
 		<Configuration
 			Name="Debug|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			UseOfATL="0"
-			ATLMinimizesCRunTimeLibraryUsage="false"
+			ATLMinimizesCRunTimeLibraryUsage="FALSE"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
-				Name="VCPreBuildEventTool"
-			/>
+				Name="VCCLCompilerTool"
+				Optimization="0"
+				OptimizeForProcessor="0"
+				AdditionalIncludeDirectories="&quot;.\include&quot;;"
+				PreprocessorDefinitions="WIN32;_WINDOWS;_DEBUG"
+				StringPooling="FALSE"
+				MinimalRebuild="TRUE"
+				BasicRuntimeChecks="3"
+				RuntimeLibrary="3"
+				BufferSecurityCheck="TRUE"
+				UsePrecompiledHeader="2"
+				WarningLevel="3"
+				Detect64BitPortabilityProblems="TRUE"
+				DebugInformationFormat="4"
+				CompileAs="2"/>
 			<Tool
-				Name="VCCustomBuildTool"
-			/>
+				Name="VCCustomBuildTool"/>
 			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
+				Name="VCLinkerTool"
+				IgnoreImportLibrary="TRUE"
+				OutputFile="$(OutDir)/mktap_basic.exe"
+				LinkIncremental="2"
+				GenerateDebugInformation="TRUE"
+				SubSystem="1"
+				ImportLibrary="$(OutDir)/mktap_basic.lib"
+				TargetMachine="1"/>
 			<Tool
 				Name="VCMIDLTool"
 				PreprocessorDefinitions="_DEBUG"
-				MkTypLibCompatible="false"
+				MkTypLibCompatible="FALSE"
 				TargetEnvironment="1"
-				GenerateStublessProxies="true"
+				GenerateStublessProxies="TRUE"
 				TypeLibraryName="$(IntDir)/mktap_basic.tlb"
 				HeaderFileName="mktap_basic.h"
 				DLLDataFileName=""
 				InterfaceIdentifierFileName="mktap_basic_i.c"
-				ProxyFileName="mktap_basic_p.c"
-			/>
+				ProxyFileName="mktap_basic_p.c"/>
 			<Tool
-				Name="VCCLCompilerTool"
-				Optimization="0"
-				AdditionalIncludeDirectories="&quot;.\include&quot;;"
-				PreprocessorDefinitions="WIN32;_WINDOWS;_DEBUG"
-				StringPooling="false"
-				MinimalRebuild="true"
-				BasicRuntimeChecks="3"
-				RuntimeLibrary="3"
-				BufferSecurityCheck="true"
-				UsePrecompiledHeader="0"
-				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
-				DebugInformationFormat="4"
-				CompileAs="2"
-			/>
+				Name="VCPostBuildEventTool"
+				Description="running $(OutDir)\$(TargetFileName)"
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
 			<Tool
 				Name="VCResourceCompilerTool"
 				PreprocessorDefinitions="_DEBUG"
 				Culture="1033"
-				AdditionalIncludeDirectories="$(IntDir)"
-			/>
+				AdditionalIncludeDirectories="$(IntDir)"/>
 			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCWebServiceProxyGeneratorTool"/>
 			<Tool
-				Name="VCLinkerTool"
-				IgnoreImportLibrary="true"
-				OutputFile="$(OutDir)/mktap_basic.exe"
-				LinkIncremental="2"
-				GenerateDebugInformation="true"
-				SubSystem="1"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				ImportLibrary="$(OutDir)/mktap_basic.lib"
-				TargetMachine="1"
-			/>
+				Name="VCXMLDataGeneratorTool"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
+				Name="VCWebDeploymentTool"/>
 			<Tool
-				Name="VCManifestTool"
-			/>
+				Name="VCManagedWrapperGeneratorTool"/>
 			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
-			<Tool
-				Name="VCPostBuildEventTool"
-				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 		<Configuration
 			Name="Release|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			UseOfATL="0"
-			ATLMinimizesCRunTimeLibraryUsage="false"
+			ATLMinimizesCRunTimeLibraryUsage="FALSE"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-				PreprocessorDefinitions="NDEBUG"
-				MkTypLibCompatible="false"
-				TargetEnvironment="1"
-				GenerateStublessProxies="true"
-				TypeLibraryName="$(IntDir)/mktap_basic.tlb"
-				HeaderFileName="mktap_basic.h"
-				DLLDataFileName=""
-				InterfaceIdentifierFileName="mktap_basic_i.c"
-				ProxyFileName="mktap_basic_p.c"
-			/>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
 				Name="VCCLCompilerTool"
 				InlineFunctionExpansion="1"
 				AdditionalIncludeDirectories="&quot;.\include&quot;;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE,POKEREVAL_LIBRARY"
-				StringPooling="true"
+				StringPooling="TRUE"
 				RuntimeLibrary="2"
-				EnableFunctionLevelLinking="true"
-				ForceConformanceInForLoopScope="true"
+				EnableFunctionLevelLinking="TRUE"
+				ForceConformanceInForLoopScope="TRUE"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
+				Detect64BitPortabilityProblems="TRUE"
 				DebugInformationFormat="3"
-				CompileAs="2"
-			/>
+				CompileAs="2"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
+				Name="VCCustomBuildTool"/>
+			<Tool
+				Name="VCLinkerTool"
+				IgnoreImportLibrary="TRUE"
+				OutputFile="$(OutDir)/mktab_basic.exe"
+				LinkIncremental="1"
+				GenerateDebugInformation="TRUE"
+				SubSystem="1"
+				OptimizeReferences="2"
+				EnableCOMDATFolding="2"
+				ImportLibrary="$(OutDir)/mktap_basic.lib"
+				TargetMachine="1"/>
+			<Tool
+				Name="VCMIDLTool"
+				PreprocessorDefinitions="NDEBUG"
+				MkTypLibCompatible="FALSE"
+				TargetEnvironment="1"
+				GenerateStublessProxies="TRUE"
+				TypeLibraryName="$(IntDir)/mktap_basic.tlb"
+				HeaderFileName="mktap_basic.h"
+				DLLDataFileName=""
+				InterfaceIdentifierFileName="mktap_basic_i.c"
+				ProxyFileName="mktap_basic_p.c"/>
+			<Tool
+				Name="VCPostBuildEventTool"
+				Description="running $(OutDir)\$(TargetFileName)"
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
+			<Tool
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
 			<Tool
 				Name="VCResourceCompilerTool"
 				PreprocessorDefinitions="NDEBUG"
 				Culture="1033"
-				AdditionalIncludeDirectories="$(IntDir)"
-			/>
+				AdditionalIncludeDirectories="$(IntDir)"/>
 			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCWebServiceProxyGeneratorTool"/>
 			<Tool
-				Name="VCLinkerTool"
-				IgnoreImportLibrary="true"
-				OutputFile="$(OutDir)/mktab_basic.exe"
-				LinkIncremental="1"
-				GenerateDebugInformation="true"
-				SubSystem="1"
-				OptimizeReferences="2"
-				EnableCOMDATFolding="2"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				ImportLibrary="$(OutDir)/mktap_basic.lib"
-				TargetMachine="1"
-			/>
+				Name="VCXMLDataGeneratorTool"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
+				Name="VCWebDeploymentTool"/>
 			<Tool
-				Name="VCManifestTool"
-			/>
+				Name="VCManagedWrapperGeneratorTool"/>
 			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
-			<Tool
-				Name="VCPostBuildEventTool"
-				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 		<Configuration
 			Name="profile|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			UseOfATL="0"
-			ATLMinimizesCRunTimeLibraryUsage="false"
+			ATLMinimizesCRunTimeLibraryUsage="FALSE"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-				PreprocessorDefinitions="NDEBUG"
-				MkTypLibCompatible="false"
-				TargetEnvironment="1"
-				GenerateStublessProxies="true"
-				TypeLibraryName="$(IntDir)/mktap_basic.tlb"
-				HeaderFileName="mktap_basic.h"
-				DLLDataFileName=""
-				InterfaceIdentifierFileName="mktap_basic_i.c"
-				ProxyFileName="mktap_basic_p.c"
-			/>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
 				Name="VCCLCompilerTool"
 				InlineFunctionExpansion="1"
 				AdditionalIncludeDirectories="&quot;.\include&quot;;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE,POKEREVAL_LIBRARY"
-				StringPooling="true"
+				StringPooling="TRUE"
 				RuntimeLibrary="2"
-				EnableFunctionLevelLinking="true"
-				ForceConformanceInForLoopScope="true"
+				EnableFunctionLevelLinking="TRUE"
+				ForceConformanceInForLoopScope="TRUE"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
+				Detect64BitPortabilityProblems="TRUE"
 				DebugInformationFormat="3"
-				CompileAs="2"
-			/>
+				CompileAs="2"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
+				Name="VCCustomBuildTool"/>
+			<Tool
+				Name="VCLinkerTool"
+				IgnoreImportLibrary="TRUE"
+				OutputFile="$(OutDir)/mktap_basic.exe"
+				LinkIncremental="1"
+				GenerateDebugInformation="TRUE"
+				SubSystem="1"
+				OptimizeReferences="2"
+				EnableCOMDATFolding="2"
+				ImportLibrary="$(OutDir)/mktap_basic.lib"
+				TargetMachine="1"/>
+			<Tool
+				Name="VCMIDLTool"
+				PreprocessorDefinitions="NDEBUG"
+				MkTypLibCompatible="FALSE"
+				TargetEnvironment="1"
+				GenerateStublessProxies="TRUE"
+				TypeLibraryName="$(IntDir)/mktap_basic.tlb"
+				HeaderFileName="mktap_basic.h"
+				DLLDataFileName=""
+				InterfaceIdentifierFileName="mktap_basic_i.c"
+				ProxyFileName="mktap_basic_p.c"/>
+			<Tool
+				Name="VCPostBuildEventTool"
+				Description="running $(OutDir)\$(TargetFileName)"
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
+			<Tool
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
 			<Tool
 				Name="VCResourceCompilerTool"
 				PreprocessorDefinitions="NDEBUG"
 				Culture="1033"
-				AdditionalIncludeDirectories="$(IntDir)"
-			/>
+				AdditionalIncludeDirectories="$(IntDir)"/>
 			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCWebServiceProxyGeneratorTool"/>
 			<Tool
-				Name="VCLinkerTool"
-				IgnoreImportLibrary="true"
-				OutputFile="$(OutDir)/mktap_basic.exe"
-				LinkIncremental="1"
-				GenerateDebugInformation="true"
-				SubSystem="1"
-				OptimizeReferences="2"
-				EnableCOMDATFolding="2"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				ImportLibrary="$(OutDir)/mktap_basic.lib"
-				TargetMachine="1"
-			/>
+				Name="VCXMLDataGeneratorTool"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
+				Name="VCWebDeploymentTool"/>
 			<Tool
-				Name="VCManifestTool"
-			/>
+				Name="VCManagedWrapperGeneratorTool"/>
 			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
-			<Tool
-				Name="VCPostBuildEventTool"
-				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 	</Configurations>
 	<References>
@@ -321,39 +236,31 @@
 	<Files>
 		<Filter
 			Name="Source Files"
-			Filter="cpp;c;cxx;def;odl;idl;hpj;bat;asm"
-			>
+			Filter="cpp;c;cxx;def;odl;idl;hpj;bat;asm">
 			<File
-				RelativePath=".\lib\mktab_basic.c"
-				>
+				RelativePath=".\lib\mktab_basic.c">
 			</File>
 			<File
-				RelativePath=".\lib\mktable.c"
-				>
+				RelativePath=".\lib\mktable.c">
 			</File>
 			<File
-				RelativePath=".\lib\mktable_utils.c"
-				>
+				RelativePath=".\lib\mktable_utils.c">
 			</File>
 		</Filter>
 		<Filter
 			Name="Header Files"
-			Filter="h;hpp;hxx;hm;inl;inc"
-			>
+			Filter="h;hpp;hxx;hm;inl;inc">
 			<File
-				RelativePath="lib\mktable.h"
-				>
+				RelativePath="lib\mktable.h">
 			</File>
 			<File
-				RelativePath="include\poker_defs.h"
-				>
+				RelativePath="include\poker_defs.h">
 			</File>
 		</Filter>
 	</Files>
 	<Globals>
 		<Global
 			Name="DevPartner_IsInstrumented"
-			Value="0"
-		/>
+			Value="0"/>
 	</Globals>
 </VisualStudioProject>

--- a/Poker.PokerEval/mktab_evx.vcproj
+++ b/Poker.PokerEval/mktab_evx.vcproj
@@ -1,276 +1,190 @@
 <?xml version="1.0" encoding="shift_jis"?>
 <VisualStudioProject
 	ProjectType="Visual C++"
-	Version="9.00"
+	Version="7.10"
 	Name="mktab_evx"
 	ProjectGUID="{88DBA3BF-5655-4239-9DAD-1DEBBC7AF182}"
-	RootNamespace="mktab_evx"
-	Keyword="Win32Proj"
-	TargetFrameworkVersion="131072"
-	>
+	Keyword="Win32Proj">
 	<Platforms>
 		<Platform
-			Name="Win32"
-		/>
+			Name="Win32"/>
 	</Platforms>
-	<ToolFiles>
-	</ToolFiles>
 	<Configurations>
 		<Configuration
 			Name="Debug|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-			/>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
+				OptimizeForProcessor="0"
 				AdditionalIncludeDirectories="&quot;.\include&quot;;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_CONSOLE"
-				StringPooling="false"
-				MinimalRebuild="true"
+				StringPooling="FALSE"
+				MinimalRebuild="TRUE"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"
-				BufferSecurityCheck="true"
-				UsePrecompiledHeader="0"
+				BufferSecurityCheck="TRUE"
+				UsePrecompiledHeader="2"
 				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
+				Detect64BitPortabilityProblems="TRUE"
 				DebugInformationFormat="4"
-				CompileAs="2"
-			/>
+				CompileAs="2"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCCustomBuildTool"/>
 			<Tool
 				Name="VCLinkerTool"
 				OutputFile="$(OutDir)/mktab_evx.exe"
 				LinkIncremental="2"
-				GenerateDebugInformation="true"
+				GenerateDebugInformation="TRUE"
 				ProgramDatabaseFile="$(OutDir)/mktab_evx.pdb"
 				SubSystem="1"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				TargetMachine="1"
-			/>
+				TargetMachine="1"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
-			<Tool
-				Name="VCManifestTool"
-			/>
-			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
+				Name="VCMIDLTool"/>
 			<Tool
 				Name="VCPostBuildEventTool"
 				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
+			<Tool
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
+			<Tool
+				Name="VCResourceCompilerTool"/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"/>
+			<Tool
+				Name="VCWebDeploymentTool"/>
+			<Tool
+				Name="VCManagedWrapperGeneratorTool"/>
+			<Tool
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 		<Configuration
 			Name="Release|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-			/>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="2"
 				InlineFunctionExpansion="1"
-				OmitFramePointers="true"
+				OmitFramePointers="TRUE"
 				AdditionalIncludeDirectories="&quot;.\include&quot;;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE,POKEREVAL_LIBRARY"
-				StringPooling="true"
+				StringPooling="TRUE"
 				RuntimeLibrary="2"
-				EnableFunctionLevelLinking="true"
-				ForceConformanceInForLoopScope="true"
+				EnableFunctionLevelLinking="TRUE"
+				ForceConformanceInForLoopScope="TRUE"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
+				Detect64BitPortabilityProblems="TRUE"
 				DebugInformationFormat="3"
-				CompileAs="2"
-			/>
+				CompileAs="2"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCCustomBuildTool"/>
 			<Tool
 				Name="VCLinkerTool"
 				OutputFile="$(OutDir)/mktab_evx.exe"
 				LinkIncremental="1"
-				GenerateDebugInformation="true"
+				GenerateDebugInformation="TRUE"
 				SubSystem="1"
 				OptimizeReferences="2"
 				EnableCOMDATFolding="2"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				TargetMachine="1"
-			/>
+				TargetMachine="1"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
-			<Tool
-				Name="VCManifestTool"
-			/>
-			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
+				Name="VCMIDLTool"/>
 			<Tool
 				Name="VCPostBuildEventTool"
 				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
+			<Tool
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
+			<Tool
+				Name="VCResourceCompilerTool"/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"/>
+			<Tool
+				Name="VCWebDeploymentTool"/>
+			<Tool
+				Name="VCManagedWrapperGeneratorTool"/>
+			<Tool
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 		<Configuration
 			Name="profile|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-			/>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="2"
 				InlineFunctionExpansion="1"
-				OmitFramePointers="true"
+				OmitFramePointers="TRUE"
 				AdditionalIncludeDirectories="&quot;.\include&quot;;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE,POKEREVAL_LIBRARY"
-				StringPooling="true"
+				StringPooling="TRUE"
 				RuntimeLibrary="2"
-				EnableFunctionLevelLinking="true"
-				ForceConformanceInForLoopScope="true"
+				EnableFunctionLevelLinking="TRUE"
+				ForceConformanceInForLoopScope="TRUE"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
+				Detect64BitPortabilityProblems="TRUE"
 				DebugInformationFormat="3"
-				CompileAs="2"
-			/>
+				CompileAs="2"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCCustomBuildTool"/>
 			<Tool
 				Name="VCLinkerTool"
 				OutputFile="$(OutDir)/mktab_evx.exe"
 				LinkIncremental="1"
-				GenerateDebugInformation="true"
+				GenerateDebugInformation="TRUE"
 				SubSystem="1"
 				OptimizeReferences="2"
 				EnableCOMDATFolding="2"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				TargetMachine="1"
-			/>
+				TargetMachine="1"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
-			<Tool
-				Name="VCManifestTool"
-			/>
-			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
+				Name="VCMIDLTool"/>
 			<Tool
 				Name="VCPostBuildEventTool"
 				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
+			<Tool
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
+			<Tool
+				Name="VCResourceCompilerTool"/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"/>
+			<Tool
+				Name="VCWebDeploymentTool"/>
+			<Tool
+				Name="VCManagedWrapperGeneratorTool"/>
+			<Tool
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 	</Configurations>
 	<References>
@@ -278,43 +192,34 @@
 	<Files>
 		<Filter
 			Name="Source Files"
-			Filter="cpp;c;cxx;def;odl;idl;hpj;bat;asm"
-			>
+			Filter="cpp;c;cxx;def;odl;idl;hpj;bat;asm">
 			<File
-				RelativePath=".\lib\mktab_evx.c"
-				>
+				RelativePath=".\lib\mktab_evx.c">
 			</File>
 			<File
-				RelativePath=".\lib\mktable.c"
-				>
+				RelativePath=".\lib\mktable.c">
 			</File>
 			<File
-				RelativePath=".\lib\mktable_utils.c"
-				>
+				RelativePath=".\lib\mktable_utils.c">
 			</File>
 		</Filter>
 		<Filter
 			Name="Header Files"
-			Filter="h;hpp;hxx;hm;inl;inc"
-			>
+			Filter="h;hpp;hxx;hm;inl;inc">
 			<File
-				RelativePath=".\include\evx_defs.h"
-				>
+				RelativePath=".\include\evx_defs.h">
 			</File>
 			<File
-				RelativePath=".\lib\mktable.h"
-				>
+				RelativePath=".\lib\mktable.h">
 			</File>
 			<File
-				RelativePath=".\include\poker_defs.h"
-				>
+				RelativePath=".\include\poker_defs.h">
 			</File>
 		</Filter>
 	</Files>
 	<Globals>
 		<Global
 			Name="DevPartner_IsInstrumented"
-			Value="0"
-		/>
+			Value="0"/>
 	</Globals>
 </VisualStudioProject>

--- a/Poker.PokerEval/mktab_joker.vcproj
+++ b/Poker.PokerEval/mktab_joker.vcproj
@@ -1,276 +1,190 @@
 <?xml version="1.0" encoding="shift_jis"?>
 <VisualStudioProject
 	ProjectType="Visual C++"
-	Version="9.00"
+	Version="7.10"
 	Name="mktab_joker"
 	ProjectGUID="{F6420BFE-310A-4A4D-9DE7-2F62B738DF7B}"
-	RootNamespace="mktab_joker"
-	Keyword="Win32Proj"
-	TargetFrameworkVersion="131072"
-	>
+	Keyword="Win32Proj">
 	<Platforms>
 		<Platform
-			Name="Win32"
-		/>
+			Name="Win32"/>
 	</Platforms>
-	<ToolFiles>
-	</ToolFiles>
 	<Configurations>
 		<Configuration
 			Name="Debug|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-			/>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
+				OptimizeForProcessor="0"
 				AdditionalIncludeDirectories="&quot;.\include&quot;;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_CONSOLE"
-				StringPooling="false"
-				MinimalRebuild="true"
+				StringPooling="FALSE"
+				MinimalRebuild="TRUE"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"
-				BufferSecurityCheck="true"
-				UsePrecompiledHeader="0"
+				BufferSecurityCheck="TRUE"
+				UsePrecompiledHeader="2"
 				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
+				Detect64BitPortabilityProblems="TRUE"
 				DebugInformationFormat="4"
-				CompileAs="2"
-			/>
+				CompileAs="2"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCCustomBuildTool"/>
 			<Tool
 				Name="VCLinkerTool"
 				OutputFile="$(OutDir)/mktab_joker.exe"
 				LinkIncremental="2"
-				GenerateDebugInformation="true"
+				GenerateDebugInformation="TRUE"
 				ProgramDatabaseFile="$(OutDir)/mktab_joker.pdb"
 				SubSystem="1"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				TargetMachine="1"
-			/>
+				TargetMachine="1"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
-			<Tool
-				Name="VCManifestTool"
-			/>
-			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
+				Name="VCMIDLTool"/>
 			<Tool
 				Name="VCPostBuildEventTool"
 				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
+			<Tool
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
+			<Tool
+				Name="VCResourceCompilerTool"/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"/>
+			<Tool
+				Name="VCWebDeploymentTool"/>
+			<Tool
+				Name="VCManagedWrapperGeneratorTool"/>
+			<Tool
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 		<Configuration
 			Name="Release|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-			/>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="2"
 				InlineFunctionExpansion="1"
-				OmitFramePointers="true"
+				OmitFramePointers="TRUE"
 				AdditionalIncludeDirectories="&quot;.\include&quot;;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE,POKEREVAL_LIBRARY"
-				StringPooling="true"
+				StringPooling="TRUE"
 				RuntimeLibrary="2"
-				EnableFunctionLevelLinking="true"
-				ForceConformanceInForLoopScope="true"
+				EnableFunctionLevelLinking="TRUE"
+				ForceConformanceInForLoopScope="TRUE"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
+				Detect64BitPortabilityProblems="TRUE"
 				DebugInformationFormat="3"
-				CompileAs="2"
-			/>
+				CompileAs="2"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCCustomBuildTool"/>
 			<Tool
 				Name="VCLinkerTool"
 				OutputFile="$(OutDir)/mktab_joker.exe"
 				LinkIncremental="1"
-				GenerateDebugInformation="true"
+				GenerateDebugInformation="TRUE"
 				SubSystem="1"
 				OptimizeReferences="2"
 				EnableCOMDATFolding="2"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				TargetMachine="1"
-			/>
+				TargetMachine="1"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
-			<Tool
-				Name="VCManifestTool"
-			/>
-			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
+				Name="VCMIDLTool"/>
 			<Tool
 				Name="VCPostBuildEventTool"
 				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
+			<Tool
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
+			<Tool
+				Name="VCResourceCompilerTool"/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"/>
+			<Tool
+				Name="VCWebDeploymentTool"/>
+			<Tool
+				Name="VCManagedWrapperGeneratorTool"/>
+			<Tool
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 		<Configuration
 			Name="profile|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-			/>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="2"
 				InlineFunctionExpansion="1"
-				OmitFramePointers="true"
+				OmitFramePointers="TRUE"
 				AdditionalIncludeDirectories="&quot;.\include&quot;;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE,POKEREVAL_LIBRARY"
-				StringPooling="true"
+				StringPooling="TRUE"
 				RuntimeLibrary="2"
-				EnableFunctionLevelLinking="true"
-				ForceConformanceInForLoopScope="true"
+				EnableFunctionLevelLinking="TRUE"
+				ForceConformanceInForLoopScope="TRUE"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
+				Detect64BitPortabilityProblems="TRUE"
 				DebugInformationFormat="3"
-				CompileAs="2"
-			/>
+				CompileAs="2"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCCustomBuildTool"/>
 			<Tool
 				Name="VCLinkerTool"
 				OutputFile="$(OutDir)/mktab_joker.exe"
 				LinkIncremental="1"
-				GenerateDebugInformation="true"
+				GenerateDebugInformation="TRUE"
 				SubSystem="1"
 				OptimizeReferences="2"
 				EnableCOMDATFolding="2"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				TargetMachine="1"
-			/>
+				TargetMachine="1"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
-			<Tool
-				Name="VCManifestTool"
-			/>
-			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
+				Name="VCMIDLTool"/>
 			<Tool
 				Name="VCPostBuildEventTool"
 				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
+			<Tool
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
+			<Tool
+				Name="VCResourceCompilerTool"/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"/>
+			<Tool
+				Name="VCWebDeploymentTool"/>
+			<Tool
+				Name="VCManagedWrapperGeneratorTool"/>
+			<Tool
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 	</Configurations>
 	<References>
@@ -278,43 +192,34 @@
 	<Files>
 		<Filter
 			Name="Source Files"
-			Filter="cpp;c;cxx;def;odl;idl;hpj;bat;asm"
-			>
+			Filter="cpp;c;cxx;def;odl;idl;hpj;bat;asm">
 			<File
-				RelativePath=".\lib\mktab_joker.c"
-				>
+				RelativePath=".\lib\mktab_joker.c">
 			</File>
 			<File
-				RelativePath=".\lib\mktable.c"
-				>
+				RelativePath=".\lib\mktable.c">
 			</File>
 			<File
-				RelativePath=".\lib\mktable_utils.c"
-				>
+				RelativePath=".\lib\mktable_utils.c">
 			</File>
 		</Filter>
 		<Filter
 			Name="Header Files"
-			Filter="h;hpp;hxx;hm;inl;inc"
-			>
+			Filter="h;hpp;hxx;hm;inl;inc">
 			<File
-				RelativePath=".\include\deck_joker.h"
-				>
+				RelativePath=".\include\deck_joker.h">
 			</File>
 			<File
-				RelativePath=".\lib\mktable.h"
-				>
+				RelativePath=".\lib\mktable.h">
 			</File>
 			<File
-				RelativePath=".\include\poker_defs.h"
-				>
+				RelativePath=".\include\poker_defs.h">
 			</File>
 		</Filter>
 	</Files>
 	<Globals>
 		<Global
 			Name="DevPartner_IsInstrumented"
-			Value="0"
-		/>
+			Value="0"/>
 	</Globals>
 </VisualStudioProject>

--- a/Poker.PokerEval/mktab_lowball.vcproj
+++ b/Poker.PokerEval/mktab_lowball.vcproj
@@ -1,276 +1,190 @@
 <?xml version="1.0" encoding="shift_jis"?>
 <VisualStudioProject
 	ProjectType="Visual C++"
-	Version="9.00"
+	Version="7.10"
 	Name="mktab_lowball"
 	ProjectGUID="{CD33AA6C-A7DF-491B-8DCF-F003F21BB89F}"
-	RootNamespace="mktab_lowball"
-	Keyword="Win32Proj"
-	TargetFrameworkVersion="131072"
-	>
+	Keyword="Win32Proj">
 	<Platforms>
 		<Platform
-			Name="Win32"
-		/>
+			Name="Win32"/>
 	</Platforms>
-	<ToolFiles>
-	</ToolFiles>
 	<Configurations>
 		<Configuration
 			Name="Debug|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-			/>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
+				OptimizeForProcessor="0"
 				AdditionalIncludeDirectories="&quot;.\include&quot;;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_CONSOLE"
-				StringPooling="false"
-				MinimalRebuild="true"
+				StringPooling="FALSE"
+				MinimalRebuild="TRUE"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"
-				BufferSecurityCheck="true"
-				UsePrecompiledHeader="0"
+				BufferSecurityCheck="TRUE"
+				UsePrecompiledHeader="2"
 				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
+				Detect64BitPortabilityProblems="TRUE"
 				DebugInformationFormat="4"
-				CompileAs="2"
-			/>
+				CompileAs="2"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCCustomBuildTool"/>
 			<Tool
 				Name="VCLinkerTool"
 				OutputFile="$(OutDir)/mktab_lowball.exe"
 				LinkIncremental="2"
-				GenerateDebugInformation="true"
+				GenerateDebugInformation="TRUE"
 				ProgramDatabaseFile="$(OutDir)/mktab_lowball.pdb"
 				SubSystem="1"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				TargetMachine="1"
-			/>
+				TargetMachine="1"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
-			<Tool
-				Name="VCManifestTool"
-			/>
-			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
+				Name="VCMIDLTool"/>
 			<Tool
 				Name="VCPostBuildEventTool"
 				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
+			<Tool
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
+			<Tool
+				Name="VCResourceCompilerTool"/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"/>
+			<Tool
+				Name="VCWebDeploymentTool"/>
+			<Tool
+				Name="VCManagedWrapperGeneratorTool"/>
+			<Tool
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 		<Configuration
 			Name="Release|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-			/>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="2"
 				InlineFunctionExpansion="1"
-				OmitFramePointers="true"
+				OmitFramePointers="TRUE"
 				AdditionalIncludeDirectories="&quot;.\include&quot;;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE,POKEREVAL_LIBRARY"
-				StringPooling="true"
+				StringPooling="TRUE"
 				RuntimeLibrary="2"
-				EnableFunctionLevelLinking="true"
-				ForceConformanceInForLoopScope="true"
+				EnableFunctionLevelLinking="TRUE"
+				ForceConformanceInForLoopScope="TRUE"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
+				Detect64BitPortabilityProblems="TRUE"
 				DebugInformationFormat="3"
-				CompileAs="2"
-			/>
+				CompileAs="2"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCCustomBuildTool"/>
 			<Tool
 				Name="VCLinkerTool"
 				OutputFile="$(OutDir)/mktab_lowball.exe"
 				LinkIncremental="1"
-				GenerateDebugInformation="true"
+				GenerateDebugInformation="TRUE"
 				SubSystem="1"
 				OptimizeReferences="2"
 				EnableCOMDATFolding="2"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				TargetMachine="1"
-			/>
+				TargetMachine="1"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
-			<Tool
-				Name="VCManifestTool"
-			/>
-			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
+				Name="VCMIDLTool"/>
 			<Tool
 				Name="VCPostBuildEventTool"
 				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
+			<Tool
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
+			<Tool
+				Name="VCResourceCompilerTool"/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"/>
+			<Tool
+				Name="VCWebDeploymentTool"/>
+			<Tool
+				Name="VCManagedWrapperGeneratorTool"/>
+			<Tool
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 		<Configuration
 			Name="profile|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-			/>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="2"
 				InlineFunctionExpansion="1"
-				OmitFramePointers="true"
+				OmitFramePointers="TRUE"
 				AdditionalIncludeDirectories="&quot;.\include&quot;;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE,POKEREVAL_LIBRARY"
-				StringPooling="true"
+				StringPooling="TRUE"
 				RuntimeLibrary="2"
-				EnableFunctionLevelLinking="true"
-				ForceConformanceInForLoopScope="true"
+				EnableFunctionLevelLinking="TRUE"
+				ForceConformanceInForLoopScope="TRUE"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
+				Detect64BitPortabilityProblems="TRUE"
 				DebugInformationFormat="3"
-				CompileAs="2"
-			/>
+				CompileAs="2"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCResourceCompilerTool"
-			/>
-			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCCustomBuildTool"/>
 			<Tool
 				Name="VCLinkerTool"
 				OutputFile="$(OutDir)/mktab_lowball.exe"
 				LinkIncremental="1"
-				GenerateDebugInformation="true"
+				GenerateDebugInformation="TRUE"
 				SubSystem="1"
 				OptimizeReferences="2"
 				EnableCOMDATFolding="2"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				TargetMachine="1"
-			/>
+				TargetMachine="1"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
-			<Tool
-				Name="VCManifestTool"
-			/>
-			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
+				Name="VCMIDLTool"/>
 			<Tool
 				Name="VCPostBuildEventTool"
 				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
+			<Tool
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
+			<Tool
+				Name="VCResourceCompilerTool"/>
+			<Tool
+				Name="VCWebServiceProxyGeneratorTool"/>
+			<Tool
+				Name="VCXMLDataGeneratorTool"/>
+			<Tool
+				Name="VCWebDeploymentTool"/>
+			<Tool
+				Name="VCManagedWrapperGeneratorTool"/>
+			<Tool
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 	</Configurations>
 	<References>
@@ -278,43 +192,34 @@
 	<Files>
 		<Filter
 			Name="Source Files"
-			Filter="cpp;c;cxx;def;odl;idl;hpj;bat;asm"
-			>
+			Filter="cpp;c;cxx;def;odl;idl;hpj;bat;asm">
 			<File
-				RelativePath=".\lib\mktab_lowball.c"
-				>
+				RelativePath=".\lib\mktab_lowball.c">
 			</File>
 			<File
-				RelativePath=".\lib\mktable.c"
-				>
+				RelativePath=".\lib\mktable.c">
 			</File>
 			<File
-				RelativePath=".\lib\mktable_utils.c"
-				>
+				RelativePath=".\lib\mktable_utils.c">
 			</File>
 		</Filter>
 		<Filter
 			Name="Header Files"
-			Filter="h;hpp;hxx;hm;inl;inc"
-			>
+			Filter="h;hpp;hxx;hm;inl;inc">
 			<File
-				RelativePath=".\include\handval_low.h"
-				>
+				RelativePath=".\include\handval_low.h">
 			</File>
 			<File
-				RelativePath=".\lib\mktable.h"
-				>
+				RelativePath=".\lib\mktable.h">
 			</File>
 			<File
-				RelativePath=".\include\poker_defs.h"
-				>
+				RelativePath=".\include\poker_defs.h">
 			</File>
 		</Filter>
 	</Files>
 	<Globals>
 		<Global
 			Name="DevPartner_IsInstrumented"
-			Value="0"
-		/>
+			Value="0"/>
 	</Globals>
 </VisualStudioProject>

--- a/Poker.PokerEval/mktab_packed.vcproj
+++ b/Poker.PokerEval/mktab_packed.vcproj
@@ -1,319 +1,233 @@
 <?xml version="1.0" encoding="shift_jis"?>
 <VisualStudioProject
 	ProjectType="Visual C++"
-	Version="9.00"
+	Version="7.10"
 	Name="mktab_packed"
 	ProjectGUID="{59C38E6B-C643-414F-A681-782E0F0A01EB}"
-	RootNamespace="mktab_packed"
-	Keyword="AtlProj"
-	TargetFrameworkVersion="131072"
-	>
+	Keyword="AtlProj">
 	<Platforms>
 		<Platform
-			Name="Win32"
-		/>
+			Name="Win32"/>
 	</Platforms>
-	<ToolFiles>
-	</ToolFiles>
 	<Configurations>
 		<Configuration
 			Name="Debug|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			UseOfATL="1"
-			ATLMinimizesCRunTimeLibraryUsage="false"
+			ATLMinimizesCRunTimeLibraryUsage="FALSE"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
-				Name="VCPreBuildEventTool"
-			/>
+				Name="VCCLCompilerTool"
+				Optimization="0"
+				OptimizeForProcessor="0"
+				AdditionalIncludeDirectories="&quot;.\include&quot;;"
+				PreprocessorDefinitions="WIN32;_WINDOWS;_DEBUG"
+				StringPooling="FALSE"
+				MinimalRebuild="TRUE"
+				BasicRuntimeChecks="3"
+				RuntimeLibrary="3"
+				BufferSecurityCheck="TRUE"
+				UsePrecompiledHeader="2"
+				WarningLevel="3"
+				Detect64BitPortabilityProblems="TRUE"
+				DebugInformationFormat="4"
+				CompileAs="2"/>
 			<Tool
-				Name="VCCustomBuildTool"
-			/>
+				Name="VCCustomBuildTool"/>
 			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
+				Name="VCLinkerTool"
+				IgnoreImportLibrary="TRUE"
+				OutputFile="$(OutDir)/mktab_packed.exe"
+				LinkIncremental="2"
+				GenerateDebugInformation="TRUE"
+				SubSystem="1"
+				ImportLibrary="$(OutDir)/mktab_packed.lib"
+				TargetMachine="1"/>
 			<Tool
 				Name="VCMIDLTool"
 				PreprocessorDefinitions="_DEBUG"
-				MkTypLibCompatible="false"
+				MkTypLibCompatible="FALSE"
 				TargetEnvironment="1"
-				GenerateStublessProxies="true"
+				GenerateStublessProxies="TRUE"
 				TypeLibraryName="$(IntDir)/mktab_packed.tlb"
 				HeaderFileName="mktab_packed.h"
 				DLLDataFileName=""
 				InterfaceIdentifierFileName="mktab_packed_i.c"
-				ProxyFileName="mktab_packed_p.c"
-			/>
+				ProxyFileName="mktab_packed_p.c"/>
 			<Tool
-				Name="VCCLCompilerTool"
-				Optimization="0"
-				AdditionalIncludeDirectories="&quot;.\include&quot;;"
-				PreprocessorDefinitions="WIN32;_WINDOWS;_DEBUG"
-				StringPooling="false"
-				MinimalRebuild="true"
-				BasicRuntimeChecks="3"
-				RuntimeLibrary="3"
-				BufferSecurityCheck="true"
-				UsePrecompiledHeader="0"
-				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
-				DebugInformationFormat="4"
-				CompileAs="2"
-			/>
+				Name="VCPostBuildEventTool"
+				Description="running $(OutDir)\$(TargetFileName)"
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
 			<Tool
 				Name="VCResourceCompilerTool"
 				PreprocessorDefinitions="_DEBUG"
 				Culture="1033"
-				AdditionalIncludeDirectories="$(IntDir)"
-			/>
+				AdditionalIncludeDirectories="$(IntDir)"/>
 			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCWebServiceProxyGeneratorTool"/>
 			<Tool
-				Name="VCLinkerTool"
-				IgnoreImportLibrary="true"
-				OutputFile="$(OutDir)/mktab_packed.exe"
-				LinkIncremental="2"
-				GenerateDebugInformation="true"
-				SubSystem="1"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				ImportLibrary="$(OutDir)/mktab_packed.lib"
-				TargetMachine="1"
-			/>
+				Name="VCXMLDataGeneratorTool"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
+				Name="VCWebDeploymentTool"/>
 			<Tool
-				Name="VCManifestTool"
-			/>
+				Name="VCManagedWrapperGeneratorTool"/>
 			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
-			<Tool
-				Name="VCPostBuildEventTool"
-				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 		<Configuration
 			Name="Release|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			UseOfATL="1"
-			ATLMinimizesCRunTimeLibraryUsage="false"
+			ATLMinimizesCRunTimeLibraryUsage="FALSE"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-				PreprocessorDefinitions="NDEBUG"
-				MkTypLibCompatible="false"
-				TargetEnvironment="1"
-				GenerateStublessProxies="true"
-				TypeLibraryName="$(IntDir)/mktab_packed.tlb"
-				HeaderFileName="mktab_packed.h"
-				DLLDataFileName=""
-				InterfaceIdentifierFileName="mktab_packed_i.c"
-				ProxyFileName="mktab_packed_p.c"
-			/>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
 				Name="VCCLCompilerTool"
 				InlineFunctionExpansion="1"
 				AdditionalIncludeDirectories="&quot;.\include&quot;;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE,POKEREVAL_LIBRARY"
-				StringPooling="true"
+				StringPooling="TRUE"
 				RuntimeLibrary="2"
-				EnableFunctionLevelLinking="true"
-				ForceConformanceInForLoopScope="true"
+				EnableFunctionLevelLinking="TRUE"
+				ForceConformanceInForLoopScope="TRUE"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
+				Detect64BitPortabilityProblems="TRUE"
 				DebugInformationFormat="3"
-				CompileAs="2"
-			/>
+				CompileAs="2"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
+				Name="VCCustomBuildTool"/>
+			<Tool
+				Name="VCLinkerTool"
+				IgnoreImportLibrary="TRUE"
+				OutputFile="$(OutDir)/mktab_packed.exe"
+				LinkIncremental="1"
+				GenerateDebugInformation="TRUE"
+				SubSystem="1"
+				OptimizeReferences="2"
+				EnableCOMDATFolding="2"
+				ImportLibrary="$(OutDir)/mktab_packed.lib"
+				TargetMachine="1"/>
+			<Tool
+				Name="VCMIDLTool"
+				PreprocessorDefinitions="NDEBUG"
+				MkTypLibCompatible="FALSE"
+				TargetEnvironment="1"
+				GenerateStublessProxies="TRUE"
+				TypeLibraryName="$(IntDir)/mktab_packed.tlb"
+				HeaderFileName="mktab_packed.h"
+				DLLDataFileName=""
+				InterfaceIdentifierFileName="mktab_packed_i.c"
+				ProxyFileName="mktab_packed_p.c"/>
+			<Tool
+				Name="VCPostBuildEventTool"
+				Description="running $(OutDir)\$(TargetFileName)"
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
+			<Tool
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
 			<Tool
 				Name="VCResourceCompilerTool"
 				PreprocessorDefinitions="NDEBUG"
 				Culture="1033"
-				AdditionalIncludeDirectories="$(IntDir)"
-			/>
+				AdditionalIncludeDirectories="$(IntDir)"/>
 			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCWebServiceProxyGeneratorTool"/>
 			<Tool
-				Name="VCLinkerTool"
-				IgnoreImportLibrary="true"
-				OutputFile="$(OutDir)/mktab_packed.exe"
-				LinkIncremental="1"
-				GenerateDebugInformation="true"
-				SubSystem="1"
-				OptimizeReferences="2"
-				EnableCOMDATFolding="2"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				ImportLibrary="$(OutDir)/mktab_packed.lib"
-				TargetMachine="1"
-			/>
+				Name="VCXMLDataGeneratorTool"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
+				Name="VCWebDeploymentTool"/>
 			<Tool
-				Name="VCManifestTool"
-			/>
+				Name="VCManagedWrapperGeneratorTool"/>
 			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
-			<Tool
-				Name="VCPostBuildEventTool"
-				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 		<Configuration
 			Name="profile|Win32"
 			OutputDirectory="mktab\$(ConfigurationName)"
 			IntermediateDirectory="obj\$(ConfigurationName)"
 			ConfigurationType="1"
-			InheritedPropertySheets="$(VCInstallDir)VCProjectDefaults\UpgradeFromVC71.vsprops"
 			UseOfATL="1"
-			ATLMinimizesCRunTimeLibraryUsage="false"
+			ATLMinimizesCRunTimeLibraryUsage="FALSE"
 			CharacterSet="2"
-			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)"
-			>
-			<Tool
-				Name="VCPreBuildEventTool"
-			/>
-			<Tool
-				Name="VCCustomBuildTool"
-			/>
-			<Tool
-				Name="VCXMLDataGeneratorTool"
-			/>
-			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
-				Name="VCMIDLTool"
-				PreprocessorDefinitions="NDEBUG"
-				MkTypLibCompatible="false"
-				TargetEnvironment="1"
-				GenerateStublessProxies="true"
-				TypeLibraryName="$(IntDir)/mktab_packed.tlb"
-				HeaderFileName="mktab_packed.h"
-				DLLDataFileName=""
-				InterfaceIdentifierFileName="mktab_packed_i.c"
-				ProxyFileName="mktab_packed_p.c"
-			/>
+			DeleteExtensionsOnClean="*.obj;*.ilk;*.pdb;*.tlb;*.tli;*.tlh;*.tmp;*.rsp;*.bat;$(TargetPath);$(IntDir);$(OutDir);$(TargetDir)">
 			<Tool
 				Name="VCCLCompilerTool"
 				InlineFunctionExpansion="1"
 				AdditionalIncludeDirectories="&quot;.\include&quot;;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE,POKEREVAL_LIBRARY"
-				StringPooling="true"
+				StringPooling="TRUE"
 				RuntimeLibrary="2"
-				EnableFunctionLevelLinking="true"
-				ForceConformanceInForLoopScope="true"
+				EnableFunctionLevelLinking="TRUE"
+				ForceConformanceInForLoopScope="TRUE"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
-				Detect64BitPortabilityProblems="true"
+				Detect64BitPortabilityProblems="TRUE"
 				DebugInformationFormat="3"
-				CompileAs="2"
-			/>
+				CompileAs="2"/>
 			<Tool
-				Name="VCManagedResourceCompilerTool"
-			/>
+				Name="VCCustomBuildTool"/>
+			<Tool
+				Name="VCLinkerTool"
+				IgnoreImportLibrary="TRUE"
+				OutputFile="$(OutDir)/mktab_packed.exe"
+				LinkIncremental="1"
+				GenerateDebugInformation="TRUE"
+				SubSystem="1"
+				OptimizeReferences="2"
+				EnableCOMDATFolding="2"
+				ImportLibrary="$(OutDir)/mktab_packed.lib"
+				TargetMachine="1"/>
+			<Tool
+				Name="VCMIDLTool"
+				PreprocessorDefinitions="NDEBUG"
+				MkTypLibCompatible="FALSE"
+				TargetEnvironment="1"
+				GenerateStublessProxies="TRUE"
+				TypeLibraryName="$(IntDir)/mktab_packed.tlb"
+				HeaderFileName="mktab_packed.h"
+				DLLDataFileName=""
+				InterfaceIdentifierFileName="mktab_packed_i.c"
+				ProxyFileName="mktab_packed_p.c"/>
+			<Tool
+				Name="VCPostBuildEventTool"
+				Description="running $(OutDir)\$(TargetFileName)"
+				CommandLine="cd $(ProjectDir)/lib
+$(TargetPath)
+"/>
+			<Tool
+				Name="VCPreBuildEventTool"/>
+			<Tool
+				Name="VCPreLinkEventTool"/>
 			<Tool
 				Name="VCResourceCompilerTool"
 				PreprocessorDefinitions="NDEBUG"
 				Culture="1033"
-				AdditionalIncludeDirectories="$(IntDir)"
-			/>
+				AdditionalIncludeDirectories="$(IntDir)"/>
 			<Tool
-				Name="VCPreLinkEventTool"
-			/>
+				Name="VCWebServiceProxyGeneratorTool"/>
 			<Tool
-				Name="VCLinkerTool"
-				IgnoreImportLibrary="true"
-				OutputFile="$(OutDir)/mktab_packed.exe"
-				LinkIncremental="1"
-				GenerateDebugInformation="true"
-				SubSystem="1"
-				OptimizeReferences="2"
-				EnableCOMDATFolding="2"
-				RandomizedBaseAddress="1"
-				DataExecutionPrevention="0"
-				ImportLibrary="$(OutDir)/mktab_packed.lib"
-				TargetMachine="1"
-			/>
+				Name="VCXMLDataGeneratorTool"/>
 			<Tool
-				Name="VCALinkTool"
-			/>
+				Name="VCWebDeploymentTool"/>
 			<Tool
-				Name="VCManifestTool"
-			/>
+				Name="VCManagedWrapperGeneratorTool"/>
 			<Tool
-				Name="VCXDCMakeTool"
-			/>
-			<Tool
-				Name="VCBscMakeTool"
-			/>
-			<Tool
-				Name="VCFxCopTool"
-			/>
-			<Tool
-				Name="VCAppVerifierTool"
-			/>
-			<Tool
-				Name="VCPostBuildEventTool"
-				Description="running $(OutDir)\$(TargetFileName)"
-				CommandLine="cd $(ProjectDir)/lib&#x0D;&#x0A;$(TargetPath)&#x0D;&#x0A;"
-			/>
+				Name="VCAuxiliaryManagedWrapperGeneratorTool"/>
 		</Configuration>
 	</Configurations>
 	<References>
@@ -321,39 +235,31 @@
 	<Files>
 		<Filter
 			Name="Source Files"
-			Filter="cpp;c;cxx;def;odl;idl;hpj;bat;asm"
-			>
+			Filter="cpp;c;cxx;def;odl;idl;hpj;bat;asm">
 			<File
-				RelativePath=".\lib\mktab_packed.c"
-				>
+				RelativePath=".\lib\mktab_packed.c">
 			</File>
 			<File
-				RelativePath=".\lib\mktable.c"
-				>
+				RelativePath=".\lib\mktable.c">
 			</File>
 			<File
-				RelativePath=".\lib\mktable_utils.c"
-				>
+				RelativePath=".\lib\mktable_utils.c">
 			</File>
 		</Filter>
 		<Filter
 			Name="Header Files"
-			Filter="h;hpp;hxx;hm;inl;inc"
-			>
+			Filter="h;hpp;hxx;hm;inl;inc">
 			<File
-				RelativePath=".\lib\mktable.h"
-				>
+				RelativePath=".\lib\mktable.h">
 			</File>
 			<File
-				RelativePath=".\include\poker_defs.h"
-				>
+				RelativePath=".\include\poker_defs.h">
 			</File>
 		</Filter>
 	</Files>
 	<Globals>
 		<Global
 			Name="DevPartner_IsInstrumented"
-			Value="0"
-		/>
+			Value="0"/>
 	</Globals>
 </VisualStudioProject>

--- a/Poker.PokerEval/tests/CMakeLists.txt
+++ b/Poker.PokerEval/tests/CMakeLists.txt
@@ -1,0 +1,40 @@
+
+add_executable(joktest1
+	${CMAKE_CURRENT_SOURCE_DIR}/tests/joktest1.c)
+target_include_directories(joktest1 PRIVATE include)
+target_link_libraries(joktest1 PRIVATE PokerEval)
+
+add_executable(enumtest1
+	${CMAKE_CURRENT_SOURCE_DIR}/tests/enumtest1.c)
+target_include_directories(enumtest1 PRIVATE include)
+target_link_libraries(enumtest1 PRIVATE PokerEval)
+
+add_executable(enumtest2
+	${CMAKE_CURRENT_SOURCE_DIR}/tests/enumtest2.c)
+target_include_directories(enumtest2 PRIVATE include)
+target_link_libraries(enumtest2 PRIVATE PokerEval)
+
+add_executable(enumtest3
+	${CMAKE_CURRENT_SOURCE_DIR}/tests/enumtest3.c)
+target_include_directories(enumtest3 PRIVATE include)
+target_link_libraries(enumtest3 PRIVATE PokerEval)
+
+add_executable(enumtest5
+	${CMAKE_CURRENT_SOURCE_DIR}/tests/enumtest5.c)
+target_include_directories(enumtest5 PRIVATE include)
+target_link_libraries(enumtest5 PRIVATE PokerEval)
+
+add_executable(enumtest7
+	${CMAKE_CURRENT_SOURCE_DIR}/tests/enumtest7.c)
+target_include_directories(enumtest7 PRIVATE include)
+target_link_libraries(enumtest7 PRIVATE PokerEval)
+
+add_executable(poker_wrapper
+	${CMAKE_CURRENT_SOURCE_DIR}/tests/poker_wrapper.c)
+target_include_directories(poker_wrapper PRIVATE include)
+target_link_libraries(poker_wrapper PRIVATE PokerEval)
+
+add_executable(razz
+	${CMAKE_CURRENT_SOURCE_DIR}/tests/razz.c)
+target_include_directories(razz PRIVATE include)
+target_link_libraries(razz PRIVATE PokerEval)

--- a/Poker.PokerEval/tests/Makefile.am
+++ b/Poker.PokerEval/tests/Makefile.am
@@ -1,24 +1,24 @@
 #
 # Copyright (C) 2004-2006 Mekensleep
 #
-# Mekensleep
-# 24 rue vieille du temple
-# 75004 Paris
-#       licensing@mekensleep.com
+# Mekensleep <licensing@mekensleep.com>
+# 24 rue vieille du temple, 75004 Paris
+#       
+# This program gives you software freedom; you can copy, convey,
+# propagate, redistribute and/or modify this program under the terms of
+# the GNU General Public License (GPL) as published by the Free Software
+# Foundation (FSF), either version 3 of the License, or (at your option)
+# any later version of the GPL published by the FSF.
 #
-#  This package is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; version 2 dated June, 1991.
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
 #
-#  This package is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along
+# with this program in a file in the toplevel directory called "GPLv3".
+# If not, see <http://www.gnu.org/licenses/>.
 #
-#  You should have received a copy of the GNU General Public License
-#  along with this package; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
-#  MA 02110-1301, USA.
 #
 # Authors:
 #  Loic Dachary <loic@dachary.org>

--- a/Poker.PokerEval/tests/bug1823
+++ b/Poker.PokerEval/tests/bug1823
@@ -27,7 +27,8 @@ Omaha Hi/Low 8-or-better: 820 enumerated boards containing Ts 8s Jc
 cards         scoop     HIwin   HIlos   HItie     LOwin   LOlos   LOtie      EV
 As Qs Kh Jh     500       715      15      90         0       0       0   0.796
 Ac Kd 5d 7h      15        15     715      90       224       0       0   0.204
-EOF)
+EOF
+)
 if test "$r" != "$e" ; then
   diff -u <(echo "$e") <(echo "$r")
   exit 1
@@ -39,7 +40,8 @@ Omaha Hi/Low 8-or-better: 820 enumerated boards containing Ts 8s Jc
 cards         scoop     HIwin   HIlos   HItie     LOwin   LOlos   LOtie      EV
 As 6s 7h 5h     250       324       0     496         0       0     168   0.675
 Ac 7d 6d 5d       0         0     324     496         0       0     168   0.325
-EOF)
+EOF
+)
 if test "$r" != "$e" ; then
   diff -u <(echo "$e") <(echo "$r")
   exit 1
@@ -51,7 +53,8 @@ Omaha Hi/Low 8-or-better: 820 enumerated boards containing Ts 2s Jc
 cards         scoop     HIwin   HIlos   HItie     LOwin   LOlos   LOtie      EV
 As 6s 7h 5h     289       381     352      87        12       0     157   0.504
 Ac 8d 6d 5d     314       352     381      87         0      12     157   0.496
-EOF)
+EOF
+)
 if test "$r" != "$e" ; then
   diff -u <(echo "$e") <(echo "$r")
   exit 1

--- a/Poker.PokerEval/tests/enumtest1.c
+++ b/Poker.PokerEval/tests/enumtest1.c
@@ -4,21 +4,22 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
-/* $Id: enumtest1.c 1773 2006-10-12 11:34:41Z loic $ */
+/* $Id: enumtest1.c 5146 2008-12-04 03:11:22Z bkuhn $ */
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/Poker.PokerEval/tests/enumtest2.c
+++ b/Poker.PokerEval/tests/enumtest2.c
@@ -4,21 +4,22 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
-/* $Id: enumtest2.c 1773 2006-10-12 11:34:41Z loic $
+/* $Id: enumtest2.c 5146 2008-12-04 03:11:22Z bkuhn $
    enumtest1.c -- test enumerate macros
 */
 

--- a/Poker.PokerEval/tests/enumtest3.c
+++ b/Poker.PokerEval/tests/enumtest3.c
@@ -4,28 +4,29 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
-/* $Id: enumtest3.c 1773 2006-10-12 11:34:41Z loic $ */
+/* $Id: enumtest3.c 6030 2009-07-07 07:23:30Z loic $ */
 
 #include <stdio.h>
 #include <stdlib.h>
 #include "poker_defs.h"
 #include "enumerate.h"
 
-int main() {
+int main(void) {
   StdDeck_CardMask set_var[2];
   int num_sets = 2;
   int set_sizes[2] = {2, 1};

--- a/Poker.PokerEval/tests/enumtest5.c
+++ b/Poker.PokerEval/tests/enumtest5.c
@@ -3,19 +3,20 @@
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 /*
  *  test program for eval_n/eval_x5

--- a/Poker.PokerEval/tests/enumtest7.c
+++ b/Poker.PokerEval/tests/enumtest7.c
@@ -3,19 +3,20 @@
  *           Brian Goetz <brian@quiotix.com>
  *           Loic Dachary <loic@dachary.org>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 /*
  *  test program for eval_n/eval_x5

--- a/Poker.PokerEval/tests/joktest1.c
+++ b/Poker.PokerEval/tests/joktest1.c
@@ -4,21 +4,22 @@
  *                 Loic Dachary <loic@dachary.org>, 
  *                 Tim Showalter <tjs@psaux.com>
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
-/* $Id: joktest1.c 1773 2006-10-12 11:34:41Z loic $
+/* $Id: joktest1.c 5146 2008-12-04 03:11:22Z bkuhn $
    joktest1.c -- compare joker evaluator with standard evaluator for those
    hands that do not include the joker
 */

--- a/Poker.PokerEval/tests/poker_wrapper.c
+++ b/Poker.PokerEval/tests/poker_wrapper.c
@@ -1,19 +1,20 @@
 /*
  *  Copyright 2006 Loic Dachary <loic@dachary.org> 
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifdef HAVE_CONFIG_H
@@ -25,7 +26,58 @@
 #include <poker_defs.h>
 #include <poker_wrapper.h>
 
-int main() {
+unsigned int wrap_StdDeck_N_CARDS(void) { return StdDeck_N_CARDS; }
+
+StdDeck_CardMask wrap_StdDeck_MASK(int index) { return StdDeck_MASK(index); }
+
+unsigned int wrap_StdDeck_Rank_2(void) { return StdDeck_Rank_2; }
+unsigned int wrap_StdDeck_Rank_3(void) { return StdDeck_Rank_3; }
+unsigned int wrap_StdDeck_Rank_4(void) { return StdDeck_Rank_4; }
+unsigned int wrap_StdDeck_Rank_5(void) { return StdDeck_Rank_5; }
+unsigned int wrap_StdDeck_Rank_6(void) { return StdDeck_Rank_6; }
+unsigned int wrap_StdDeck_Rank_7(void) { return StdDeck_Rank_7; }
+unsigned int wrap_StdDeck_Rank_8(void) { return StdDeck_Rank_8; }
+unsigned int wrap_StdDeck_Rank_9(void) { return StdDeck_Rank_9; }
+unsigned int wrap_StdDeck_Rank_TEN(void) { return StdDeck_Rank_TEN; }
+unsigned int wrap_StdDeck_Rank_JACK(void) { return StdDeck_Rank_JACK; }
+unsigned int wrap_StdDeck_Rank_QUEEN(void) { return StdDeck_Rank_QUEEN; }
+unsigned int wrap_StdDeck_Rank_KING(void) { return StdDeck_Rank_KING; }
+unsigned int wrap_StdDeck_Rank_ACE(void) { return StdDeck_Rank_ACE; }
+unsigned int wrap_StdDeck_Rank_COUNT(void) { return StdDeck_Rank_COUNT; }
+unsigned int wrap_StdDeck_Rank_FIRST(void) { return StdDeck_Rank_FIRST; }
+unsigned int wrap_StdDeck_Rank_LAST(void) { return StdDeck_Rank_LAST; }
+unsigned int wrap_StdDeck_RANK(unsigned int index) { return StdDeck_RANK(index); }
+unsigned int wrap_StdDeck_SUIT(unsigned int index) { return StdDeck_SUIT(index); }
+unsigned int wrap_StdDeck_MAKE_CARD(unsigned int rank, unsigned int suit) { return StdDeck_MAKE_CARD(rank, suit); }
+unsigned int wrap_StdDeck_Suit_HEARTS(void) { return StdDeck_Suit_HEARTS; }
+unsigned int wrap_StdDeck_Suit_DIAMONDS(void) { return StdDeck_Suit_DIAMONDS; }
+unsigned int wrap_StdDeck_Suit_CLUBS(void) { return StdDeck_Suit_CLUBS; }
+unsigned int wrap_StdDeck_Suit_SPADES(void) { return StdDeck_Suit_SPADES; }
+unsigned int wrap_StdDeck_Suit_FIRST(void) { return StdDeck_Suit_FIRST; }
+unsigned int wrap_StdDeck_Suit_LAST(void) { return StdDeck_Suit_LAST; }
+unsigned int wrap_StdDeck_Suit_COUNT(void) { return StdDeck_Suit_COUNT; }
+
+unsigned int wrap_StdDeck_CardMask_SPADES(StdDeck_CardMask cm) { return StdDeck_CardMask_SPADES(cm); }
+unsigned int wrap_StdDeck_CardMask_CLUBS(StdDeck_CardMask cm) { return StdDeck_CardMask_CLUBS(cm); }
+unsigned int wrap_StdDeck_CardMask_DIAMONDS(StdDeck_CardMask cm) { return StdDeck_CardMask_DIAMONDS(cm); }
+unsigned int wrap_StdDeck_CardMask_HEARTS(StdDeck_CardMask cm) { return StdDeck_CardMask_HEARTS(cm); }
+StdDeck_CardMask wrap_StdDeck_CardMask_SET_HEARTS(StdDeck_CardMask cm, unsigned int ranks) { StdDeck_CardMask_SET_HEARTS(cm, ranks); return cm; }
+StdDeck_CardMask wrap_StdDeck_CardMask_SET_DIAMONDS(StdDeck_CardMask cm, unsigned int ranks) { StdDeck_CardMask_SET_DIAMONDS(cm, ranks); return cm; }
+StdDeck_CardMask wrap_StdDeck_CardMask_SET_CLUBS(StdDeck_CardMask cm, unsigned int ranks) { StdDeck_CardMask_SET_CLUBS(cm, ranks); return cm; }
+StdDeck_CardMask wrap_StdDeck_CardMask_SET_SPADES(StdDeck_CardMask cm, unsigned int ranks) { StdDeck_CardMask_SET_SPADES(cm, ranks); return cm; }
+StdDeck_CardMask wrap_StdDeck_CardMask_NOT(StdDeck_CardMask cm) { StdDeck_CardMask_NOT(cm, cm); return cm; }
+StdDeck_CardMask wrap_StdDeck_CardMask_OR(StdDeck_CardMask op1, StdDeck_CardMask op2) { StdDeck_CardMask_OR(op1, op1, op2); return op1; } 
+StdDeck_CardMask wrap_StdDeck_CardMask_AND(StdDeck_CardMask op1, StdDeck_CardMask op2) { StdDeck_CardMask_AND(op1, op1, op2); return op1; } 
+StdDeck_CardMask wrap_StdDeck_CardMask_XOR(StdDeck_CardMask op1, StdDeck_CardMask op2) { StdDeck_CardMask_XOR(op1, op1, op2); return op1; } 
+StdDeck_CardMask wrap_StdDeck_CardMask_SET(StdDeck_CardMask mask, unsigned int index) { StdDeck_CardMask_SET(mask, index); return mask; } ;
+StdDeck_CardMask wrap_StdDeck_CardMask_UNSET(StdDeck_CardMask mask, unsigned int index) { StdDeck_CardMask_UNSET(mask, index); return mask; }
+int wrap_StdDeck_CardMask_CARD_IS_SET(StdDeck_CardMask mask, unsigned int index) { return StdDeck_CardMask_CARD_IS_SET(mask, index); }
+int wrap_StdDeck_CardMask_ANY_SET(StdDeck_CardMask mask1, StdDeck_CardMask mask2) { return StdDeck_CardMask_ANY_SET(mask1, mask2); }
+StdDeck_CardMask wrap_StdDeck_CardMask_RESET(void) { StdDeck_CardMask mask; StdDeck_CardMask_RESET(mask); return mask; }
+int wrap_StdDeck_CardMask_IS_EMPTY(StdDeck_CardMask mask) { return StdDeck_CardMask_IS_EMPTY(mask); }
+int wrap_StdDeck_CardMask_EQUAL(StdDeck_CardMask mask1, StdDeck_CardMask mask2) { return StdDeck_CardMask_EQUAL(mask1, mask2); }
+
+int main(void) {
   {
     assert(wrap_StdDeck_N_CARDS() == 52);
   }

--- a/Poker.PokerEval/tests/razz.c
+++ b/Poker.PokerEval/tests/razz.c
@@ -1,19 +1,20 @@
 /*
  *  Copyright 2006 Loic Dachary <loic@dachary.org> 
  *
- *  This package is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; version 2 dated June, 1991.
+ * This program gives you software freedom; you can copy, convey,
+ * propagate, redistribute and/or modify this program under the terms of
+ * the GNU General Public License (GPL) as published by the Free Software
+ * Foundation (FSF), either version 3 of the License, or (at your option)
+ * any later version of the GPL published by the FSF.
  *
- *  This package is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this package; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
- *  MA 02110-1301, USA.
+ * You should have received a copy of the GNU General Public License along
+ * with this program in a file in the toplevel directory called "GPLv3".
+ * If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifdef HAVE_CONFIG_H

--- a/Poker.PokerEval/tests/razz.c
+++ b/Poker.PokerEval/tests/razz.c
@@ -112,8 +112,8 @@ int main(int argc, char* argv[]) {
 
     if(verbose) enumResultPrint(&result, pockets, board);
 
-    assert(result.ev[0] == 1.0);
-    assert(result.ev[1] == 0.0);
+    assert(result.ev[0] == 0.0);
+    assert(result.ev[1] == 1.0);
   }
 
   return 0;

--- a/Poker.PokerEval/tests/run.in
+++ b/Poker.PokerEval/tests/run.in
@@ -6,19 +6,22 @@
 #           Tim Showalter <tjs@psaux.com>
 #           Loic Dachary <loic@dachary.org>
 #
-#  This package is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; version 2 dated June, 1991.
 #
-#  This package is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
+# This program gives you software freedom; you can copy, convey,
+# propagate, redistribute and/or modify this program under the terms of
+# the GNU General Public License (GPL) as published by the Free Software
+# Foundation (FSF), either version 3 of the License, or (at your option)
+# any later version of the GPL published by the FSF.
 #
-#  You should have received a copy of the GNU General Public License
-#  along with this package; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
-#  MA 02110-1301, USA.
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program in a file in the toplevel directory called "GPLv3".
+# If not, see <http://www.gnu.org/licenses/>.
+#
 #
 
 set -e


### PR DESCRIPTION
This incorporates changes from the [pokermania/pokereval](https://github.com/pokermania/pokereval) repository, which as far as I'm able to tell appears to be the best location to obtain the base poker-eval repository from. This also adds poker-eval tests to the CI/CD environment on each push, allowing not only for the overall Poker Equity Test to be ran, but also for the poker-eval tests to be ran. Along with that I have a few changes I made:
* I couldn't directly just copy/paste the other poker-eval repository as it looks like some t_ files need to be generated and I'm uncertain how to do that. So instead, I went file-by-file and incorporated the changes into the files that appeared to need it
* I'm not using the automake files it came with but instead using the (much more user friendly) CMakeLists.txt files that I've added to the repository. I've replicated rebuilding the project using these cmake files
* Tests from `Poker.PokerEval/tests/run.in` and `Poker.PokerEval/examples/utest1` have been incorporated into the CI/CD flow
* Some tests in `Poker.PokerEval/examples/utest1` did not run, either due to incorrect command-line arguments or the test program reporting that the requested test is not supported. These tests have been omitted
* There are tests in `Poker.PokerEval/tests/bug1823` that are not incorporated here
* I've modified the file `Poker.PokerEval/tests/razz.c` as it appears as though the testing logic for the second case was in reverse and thus always failed. I am personally unfamiliar with the rules of Razz poker, so I used [an external website](https://www.cardplayer.com/poker-tools/odds-calculator/razz) to enter the hands and verify that the output is correct. It looks like the library was correctly evaluating the result, but the test was incorrectly checking the return.
* License has been updated to GPLv3, which is the updated license from the newer codebase
* The tools `evx_gen5` and `evx_gen7` do not appear to successfully compile. I've commented out those builds but left them in the overall CMakeLists.txt file to look into in the future
* I had to modify the `Poker.PokerEval/tests/poker_wrapper.c` file to add the wrapper functions which were not present in the above referenced repository. However, I found [another repository](https://github.com/dooglus/pokereval/blob/920dc2d7081f7d58647853d94b860015258916ac/lib/poker_wrapper.c) which had definitions for those functions